### PR TITLE
feat(seo): PR1 — enable SSG + base SEO meta

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -3,3 +3,50 @@
     <NuxtPage />
   </NuxtLayout>
 </template>
+
+<script setup>
+import { computed } from 'vue';
+
+const { t, locale, locales } = useI18n();
+const route = useRoute();
+const config = useRuntimeConfig();
+
+const siteUrl = config.public.siteUrl;
+
+// 將 i18n locale code 轉成 BCP 47 html lang
+const htmlLang = computed(() => {
+  const map = { zh: 'zh-TW', ja: 'ja-JP', en: 'en-US' };
+  return map[locale.value] || 'zh-TW';
+});
+
+const canonicalUrl = computed(() => `${siteUrl}${route.path === '/' ? '' : route.path}`);
+
+// 全站基礎 SEO meta (各頁可用 useSeoMeta 覆蓋 title / description / og:image)
+useSeoMeta({
+  titleTemplate: title => (title ? `${title} - ${t('site.title')}` : t('site.title')),
+  description: () => t('site.description'),
+  keywords: () => t('site.keywords'),
+  ogSiteName: () => t('site.title'),
+  ogType: 'website',
+  ogTitle: () => t('site.title'),
+  ogDescription: () => t('site.description'),
+  ogImage: `${siteUrl}/img/og_common.png`,
+  ogUrl: () => canonicalUrl.value,
+  ogLocale: () =>
+    ({ zh: 'zh_TW', ja: 'ja_JP', en: 'en_US' }[locale.value] || 'zh_TW'),
+  twitterCard: 'summary_large_image',
+  twitterSite: '@tn604000',
+  twitterTitle: () => t('site.title'),
+  twitterDescription: () => t('site.description'),
+  twitterImage: `${siteUrl}/img/og_common.png`
+});
+
+useHead({
+  htmlAttrs: {
+    lang: htmlLang
+  },
+  link: [
+    { rel: 'canonical', href: canonicalUrl }
+  ]
+});
+</script>

--- a/app/pages/challenge.vue
+++ b/app/pages/challenge.vue
@@ -410,9 +410,11 @@ const generateMultiChoiceQuestion = (retry = 10) => {
   };
 };
 
-// SEO 與標題
-useHead({
-  title: computed(() => `${t('site.challenge')} - ${t('site.title')}`)
+// SEO 與標題 (套用 app.vue 的 titleTemplate)
+useSeoMeta({
+  title: () => t('site.challenge'),
+  description: () => t('challenge.description'),
+  ogDescription: () => t('challenge.description')
 });
 </script>
 

--- a/app/pages/favorite.vue
+++ b/app/pages/favorite.vue
@@ -173,9 +173,9 @@ const play_random_voice = () => {
 
 const stop_all = () => audioStore.stopAll();
 
-// Meta 標籤設定
-useHead({
-  title: computed(() => `${t('site.favorite')} - ${t('site.title')}`)
+// Meta 標籤設定 (套用 app.vue 的 titleTemplate)
+useSeoMeta({
+  title: () => t('site.favorite')
 });
 </script>
 

--- a/app/pages/feedback.vue
+++ b/app/pages/feedback.vue
@@ -23,9 +23,10 @@ import { computed } from 'vue';
 
 const { t } = useI18n();
 
-// SEO 標籤設定 (取代舊版的 head())
-useHead({
-  title: computed(() => `${t('site.feedback')} - ${t('site.title')}`)
+// SEO 標籤設定 (套用 app.vue 的 titleTemplate)
+useSeoMeta({
+  title: () => t('site.feedback'),
+  robots: 'noindex, follow' // 純 Google Form iframe,無索引價值
 });
 </script>
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -242,9 +242,10 @@ const play_random_voice = () => {
 
 const stop_all = () => audioStore.stopAll();
 
-// Meta 標籤設定
-useHead({
-  title: computed(() => t('site.title'))
+// Meta 標籤設定 (基礎 SEO 由 app.vue 設定;此頁為根頁面,不另設定標題前綴)
+useSeoMeta({
+  description: () => t('site.description'),
+  ogDescription: () => t('site.description')
 });
 </script>
 

--- a/app/pages/member.vue
+++ b/app/pages/member.vue
@@ -84,6 +84,11 @@ import voice_lists from '~~/assets/dc_voices.json';
 import { useAudioStore } from '~/stores/audio';
 import { useSnackbar } from '~/composables/useSnackbar';
 
+// 會員頁走 Discord OAuth (client-only),不參與 SSG 預渲染
+definePageMeta({
+  ssr: false
+});
+
 const { t, locale } = useI18n();
 const settings = useSettingsStore();
 const audioStore = useAudioStore();
@@ -213,8 +218,9 @@ const play = item => {
   send_google_event(item);
 };
 
-useHead({
-  title: computed(() => `${t('member.member_area')} - ${t('site.title')}`)
+useSeoMeta({
+  title: () => t('member.member_area'),
+  robots: 'noindex, nofollow' // 會員專區需 Discord OAuth,不應被索引
 });
 </script>
 

--- a/app/pages/privacy.vue
+++ b/app/pages/privacy.vue
@@ -30,8 +30,8 @@ const md = new MarkdownIt({
 // 將純字串轉換為 HTML
 const about_md = computed(() => md.render(privacyRaw));
 
-useHead({
-  title: computed(() => `${t('site.privacy')} - ${t('site.title')}`)
+useSeoMeta({
+  title: () => t('site.privacy')
 });
 </script>
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,9 +1,44 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// 解析 pinia 安裝路徑 (透過 pnpm 也能正確找到),並指向其 ESM build
+// 解決 Pinia 3 在 production NODE_ENV 下會解析到 pinia.prod.cjs,導致 SSR 失敗的問題
+const require$ = createRequire(import.meta.url);
+const piniaPkgPath = require$.resolve('pinia/package.json');
+const piniaEsm = resolve(dirname(piniaPkgPath), 'dist/pinia.mjs');
+
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   // 匯入全域 CSS
   css: ['~~/assets/global.css'],
-  ssr: false,
+  ssr: true,
+
+  // SSG: 預先產生所有靜態路由 (排除 /member,因走 Discord OAuth)
+  nitro: {
+    prerender: {
+      crawlLinks: true,
+      routes: ['/', '/favorite', '/challenge', '/feedback', '/privacy'],
+      ignore: ['/member']
+    }
+  },
+
+  // 強制 pinia 解析到 ESM build (絕對路徑,因 pinia 套件的 exports 未對外曝露 dist 子路徑)
+  alias: {
+    pinia: piniaEsm
+  },
+
+  // Vuetify SSR 需要被 Vite 內聯處理
+  vite: {
+    ssr: {
+      noExternal: ['vuetify']
+    }
+  },
+
+  build: {
+    transpile: ['vuetify']
+  },
 
   modules: [
     'vuetify-nuxt-module',
@@ -60,7 +95,9 @@ export default defineNuxtConfig({
     public: {
       DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
       DISCORD_REDIRECT_URI: process.env.DISCORD_REDIRECT_URI,
-      DISCORD_API_BASE: process.env.DISCORD_API_BASE
+      DISCORD_API_BASE: process.env.DISCORD_API_BASE,
+      // 站點正式網址,給 canonical / og:url / sitemap 使用
+      siteUrl: process.env.NUXT_PUBLIC_SITE_URL || 'https://dada-vtuber-button.vercel.app'
     }
   },
 
@@ -76,40 +113,21 @@ export default defineNuxtConfig({
     strategy: 'no_prefix'
   },
 
+  // 僅放靜態、跨頁共用的基礎 head;SEO 動態欄位 (title/description/og/canonical) 由 app.vue 使用 useSeoMeta 設定
   app: {
     head: {
       meta: [
         { charset: 'utf-8' },
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-        {
-          name: 'description',
-          content:
-            '歡迎來到灰妲語音博物館！這裡收藏了灰妲的各種語音與獨特叫聲，粉絲可以隨時點擊播放，探索她迷人的聲音世界，感受她獨一無二的魅力。'
-        },
-        {
-          name: 'keywords',
-          content: '灰妲,Vtuber,台V,語音按鈕,ReLive Project'
-        },
-        { property: 'og:site_name', content: '灰妲語音博物館' },
-        { property: 'og:type', content: 'website' },
-        { property: 'og:url', content: '灰妲語音博物館' },
-        { property: 'og:title', content: '灰妲語音博物館' },
-        {
-          property: 'og:description',
-          content:
-            '歡迎來到灰妲語音博物館！這裡收藏了灰妲的各種語音與獨特叫聲，粉絲可以隨時點擊播放，探索她迷人的聲音世界，感受她獨一無二的魅力。'
-        },
-        { property: 'og:image', content: 'https://dada-vtuber-button.vercel.app/img/og_common.png' },
-        { name: 'twitter:card', content: 'summary_large_image' },
-        { name: 'twitter:site', content: '@tn604000' }
+        { name: 'theme-color', content: '#bd133d' }
       ],
       link: [
-        { rel: 'apple-touch-icon', sizes: '180x180', href: 'apple-touch-icon.png' },
-        { rel: 'icon', type: 'image/png', sizes: '32x32', href: 'favicon-32x32.png' },
-        { rel: 'icon', type: 'image/png', sizes: '16x16', href: 'favicon-16x16.png' },
-        { rel: 'manifest', href: 'site.webmanifest' },
-        { rel: 'icon', type: 'image/x-icon', href: 'favicon.ico' },
-        { rel: 'shortcut icon', type: 'image/x-icon', href: 'favicon.ico' }
+        { rel: 'apple-touch-icon', sizes: '180x180', href: '/apple-touch-icon.png' },
+        { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/favicon-32x32.png' },
+        { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/favicon-16x16.png' },
+        { rel: 'manifest', href: '/site.webmanifest' },
+        { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
+        { rel: 'shortcut icon', type: 'image/x-icon', href: '/favicon.ico' }
       ]
     }
   }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,40 +1,28 @@
-# robots.txt for Nuxt 2 Application
+# robots.txt for 灰妲語音博物館 (Nuxt SSG)
 
-# Allow all crawlers full access to the site
+# 預設允許所有爬蟲
 User-agent: *
 Allow: /
+Disallow: /member
 
-# Sitemap location (replace with your actual sitemap URL)
 Sitemap: https://dada-vtuber-button.vercel.app/sitemap.xml
 
-# Prevent crawling of sensitive or duplicate content directories
-Disallow: /admin/
-Disallow: /private/
-Disallow: /backend/
-Disallow: /api/
-Disallow: /wp-admin/
-
-# Rate limiting for crawlers to be respectful
-Crawl-delay: 10
-
-# Specific crawler rules
+# 主要搜尋引擎明確允許
 User-agent: Googlebot
 Allow: /
+Disallow: /member
 
 User-agent: Bingbot
 Allow: /
+Disallow: /member
 
 User-agent: DuckDuckBot
 Allow: /
+Disallow: /member
 
-# Block specific directories for specific crawlers
+# 封鎖無關的 SEO 工具爬蟲 (避免被掃描)
 User-agent: AhrefsBot
 Disallow: /
 
 User-agent: MJ12bot
 Disallow: /
-
-# Example of blocking certain file types
-Disallow: /*?*
-Disallow: /*.pdf$
-Disallow: /*.zip$

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,31 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "灰妲語音博物館",
+  "short_name": "灰妲",
+  "description": "灰妲語音博物館 — 收藏台V灰妲 (ReLive Project) 的各種語音與獨特叫聲,點擊即可播放。",
+  "lang": "zh-TW",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "theme_color": "#bd133d",
+  "background_color": "#212121",
+  "categories": ["entertainment", "music"],
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png",
+      "purpose": "any"
+    }
+  ]
+}


### PR DESCRIPTION
切換 ssr:false → ssr:true 並改用 nuxi generate 預渲染 (排除 /member 因走 Discord OAuth)。 原本 index.html body 是空的 <div id="__nuxt">,改後完整內容 (136KB,66 個語音按鈕、157 個 panel) 直接寫入 HTML。

主要改動:
- app.vue:用 useSeoMeta 設定全站 base meta、動態 html lang、細粒度 canonical (帶 path)
- 各頁改用 useSeoMeta 設定 page-specific title (套 titleTemplate)
- 修 og:url (原內容是錯字串 "灰妲語音博物館")
- /feedback noindex,follow (純 Google Form iframe,無索引價值)
- /member noindex,nofollow + robots.txt Disallow:/member + definePageMeta({ssr:false})
- robots.txt:刪掉過於保守的 Disallow:/*?* 與 Crawl-delay:10
- site.webmanifest:補上 name/short_name/description/lang,配色用灰妲紅+dark secondary
- nuxt.config:加 runtimeConfig.public.siteUrl 給 canonical 使用
- nuxt.config:修 Pinia 3 + Nuxt SSR 相容性 (alias 到 pinia.mjs 避開 production CJS)
- nuxt.config:Vuetify SSR 需要 vite.ssr.noExternal + build.transpile