### PR TITLE
perf(icons): PR5 — migrate MDI from font (403KB) to SVG icons

### DIFF
--- a/app/components/VoiceBtn.vue
+++ b/app/components/VoiceBtn.vue
@@ -37,19 +37,19 @@
               class="vo-menu-btn-bg"
               :class="{ liked: in_favorite }"
             >
-              <v-icon icon="mdi-menu" color="white"></v-icon>
+              <v-icon :icon="mdiMenu" color="white"></v-icon>
             </v-btn>
           </template>
           <v-list density="compact">
             <v-list-item
               v-if="in_favorite"
-              prepend-icon="mdi-heart-minus"
+              :prepend-icon="mdiHeartMinus"
               :title="$t('action.unlike')"
               @click="onUnlike"
             ></v-list-item>
-            <v-list-item v-else prepend-icon="mdi-heart-plus" :title="$t('action.like')" @click="onLike"></v-list-item>
-            <v-list-item prepend-icon="mdi-youtube" :title="$t('action.view_stream')" @click="onYoutube"></v-list-item>
-            <v-list-item prepend-icon="mdi-download" :title="$t('action.download')" @click="onDownload"></v-list-item>
+            <v-list-item v-else :prepend-icon="mdiHeartPlus" :title="$t('action.like')" @click="onLike"></v-list-item>
+            <v-list-item :prepend-icon="mdiYoutube" :title="$t('action.view_stream')" @click="onYoutube"></v-list-item>
+            <v-list-item :prepend-icon="mdiDownload" :title="$t('action.download')" @click="onDownload"></v-list-item>
           </v-list>
         </v-menu>
       </v-btn-group>
@@ -82,6 +82,7 @@
 <script setup>
 import { computed, useSlots } from 'vue';
 import { useTheme } from 'vuetify';
+import { mdiMenu, mdiHeartMinus, mdiHeartPlus, mdiYoutube, mdiDownload } from '@mdi/js';
 import twemoji from 'twemoji';
 
 defineOptions({

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -12,25 +12,25 @@
         <v-list-item
           :to="localePath('/favorite')"
           exact
-          prepend-icon="mdi-heart-outline"
+          :prepend-icon="mdiHeartOutline"
           :title="$t('site.favorite')"
         ></v-list-item>
         <v-list-item
           :to="localePath('/challenge')"
           exact
-          prepend-icon="mdi-head-question-outline"
+          :prepend-icon="mdiHeadQuestionOutline"
           :title="$t('site.challenge')"
         ></v-list-item>
         <v-list-item
           :to="localePath('/feedback')"
           exact
-          prepend-icon="mdi-message-alert-outline"
+          :prepend-icon="mdiMessageAlertOutline"
           :title="$t('site.feedback')"
         ></v-list-item>
         <v-list-item
           :to="localePath('/member')"
           exact
-          prepend-icon="mdi-account-group"
+          :prepend-icon="mdiAccountGroup"
           :title="$t('member.member_area')"
         ></v-list-item>
       </v-list>
@@ -74,11 +74,11 @@
       <v-menu :close-on-content-click="false">
         <template #activator="{ props }">
           <v-btn icon variant="plain" v-bind="props">
-            <v-icon icon="mdi-volume-high"></v-icon>
+            <v-icon :icon="mdiVolumeHigh"></v-icon>
           </v-btn>
         </template>
         <v-sheet class="pa-2 align-center" width="256" style="display: flex">
-          <v-icon icon="mdi-volume-low" color="primary" class="mr-2"></v-icon>
+          <v-icon :icon="mdiVolumeLow" color="primary" class="mr-2"></v-icon>
           <v-slider
             v-model="volume"
             :min="0"
@@ -88,14 +88,14 @@
             color="#ff8a80"
             @update:model-value="onVolumeChange"
           ></v-slider>
-          <v-icon icon="mdi-volume-high" color="primary" class="ml-2"></v-icon>
+          <v-icon :icon="mdiVolumeHigh" color="primary" class="ml-2"></v-icon>
         </v-sheet>
       </v-menu>
 
       <v-tooltip location="bottom">
         <template #activator="{ props }">
           <v-btn icon variant="plain" v-bind="props" @click="toggleTheme">
-            <v-icon icon="mdi-brightness-2"></v-icon>
+            <v-icon :icon="mdiBrightness2"></v-icon>
           </v-btn>
         </template>
         <span>{{ $t('site.switch_dark_mode') }}</span>
@@ -106,7 +106,7 @@
           <v-tooltip location="bottom">
             <template #activator="{ props: tooltipProps }">
               <v-btn icon variant="plain" v-bind="mergeProps(menuProps, tooltipProps)">
-                <v-icon icon="mdi-translate"></v-icon>
+                <v-icon :icon="mdiTranslate"></v-icon>
               </v-btn>
             </template>
             <span>{{ $t('site.switch_language') }}</span>
@@ -161,6 +161,16 @@
 <script setup>
 import { ref, computed, onMounted, watch, mergeProps } from 'vue';
 import { useTheme } from 'vuetify';
+import {
+  mdiHeartOutline,
+  mdiHeadQuestionOutline,
+  mdiMessageAlertOutline,
+  mdiAccountGroup,
+  mdiVolumeHigh,
+  mdiVolumeLow,
+  mdiBrightness2,
+  mdiTranslate
+} from '@mdi/js';
 import { useSettingsStore } from '~/stores/settings';
 import { useSnackbar } from '~/composables/useSnackbar';
 import navigatorItems from '~~/assets/navigator.json';

--- a/app/pages/challenge.vue
+++ b/app/pages/challenge.vue
@@ -98,12 +98,12 @@
                     </VoiceBtn>
 
                     <div v-if="show_result" class="ml-3">
-                      <v-icon v-if="option.correct" color="success" size="24" icon="mdi-check-circle"></v-icon>
+                      <v-icon v-if="option.correct" color="success" size="24" :icon="mdiCheckCircle"></v-icon>
                       <v-icon
                         v-else-if="answers[question.id] === option.id"
                         color="error"
                         size="24"
-                        icon="mdi-close-circle"
+                        :icon="mdiCloseCircle"
                       ></v-icon>
                     </div>
                   </div>
@@ -136,9 +136,9 @@
                         v-if="isCorrect(question, option)"
                         color="success"
                         size="24"
-                        icon="mdi-check-circle"
+                        :icon="mdiCheckCircle"
                       ></v-icon>
-                      <v-icon v-else color="error" size="24" icon="mdi-close-circle"></v-icon>
+                      <v-icon v-else color="error" size="24" :icon="mdiCloseCircle"></v-icon>
                     </div>
                   </div>
                 </template>
@@ -175,6 +175,7 @@
 
 <script setup>
 import { ref, computed, watch } from 'vue';
+import { mdiCheckCircle, mdiCloseCircle } from '@mdi/js';
 import voice_lists from '~~/assets/voices.json';
 import VoiceBtn from '../components/VoiceBtn.vue';
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -25,7 +25,7 @@
               {{ group.voice_list.length }}
             </v-chip>
             <v-btn tag="span" class="flex-grow-0" icon variant="plain" @click.stop="copyLink(group.id)">
-              <v-icon icon="mdi-link"></v-icon>
+              <v-icon :icon="mdiLink"></v-icon>
             </v-btn>
           </v-expansion-panel-title>
 
@@ -99,6 +99,7 @@
 
 <script setup>
 import { ref, computed, watch, onMounted, nextTick } from 'vue';
+import { mdiLink } from '@mdi/js';
 import voice_lists from '~~/assets/voices.json';
 
 // 全域工具

--- a/app/pages/member.vue
+++ b/app/pages/member.vue
@@ -55,7 +55,7 @@
                 {{ group.voice_list.length }}
               </v-chip>
               <v-btn tag="span" class="flex-grow-0" icon variant="plain" @click.stop="copyLink(group.id)">
-                <v-icon icon="mdi-link"></v-icon>
+                <v-icon :icon="mdiLink"></v-icon>
               </v-btn>
             </v-expansion-panel-title>
 
@@ -79,6 +79,7 @@
 
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { mdiLink } from '@mdi/js';
 import voice_lists from '~~/assets/dc_voices.json';
 // 💡 引入 AudioStore 與 Snackbar
 import { useAudioStore } from '~/stores/audio';

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -100,6 +100,11 @@ export default defineNuxtConfig({
       /* 模組選項 */
     },
     vuetifyOptions: {
+      // 使用 SVG icon set (從 @mdi/js 個別 import,只 bundle 用到的 icon)
+      // 取代原本的 mdi-font webfont (403KB woff2)
+      icons: {
+        defaultSet: 'mdi-svg'
+      },
       theme: {
         defaultTheme: 'dark',
         themes: {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint ./app"
   },
   "dependencies": {
+    "@mdi/js": "^7.4.47",
     "markdown-it": "^14.1.1",
     "nuxt": "^4.3.1",
     "twemoji": "^14.0.2",
@@ -21,7 +22,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mdi/font": "^7.4.47",
     "@nuxt/image": "^2.0.0",
     "@nuxtjs/i18n": "^10.2.3",
     "@nuxtjs/seo": "^5.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@mdi/js':
+        specifier: ^7.4.47
+        version: 7.4.47
       markdown-it:
         specifier: ^14.1.1
         version: 14.1.1
@@ -30,9 +33,6 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.0.2(jiti@2.6.1))
-      '@mdi/font':
-        specifier: ^7.4.47
-        version: 7.4.47
       '@nuxt/image':
         specifier: ^2.0.0
         version: 2.0.0(db0@0.3.4)(ioredis@5.10.0)(magicast@0.5.2)
@@ -961,8 +961,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@mdi/font@7.4.47':
-    resolution: {integrity: sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==}
+  '@mdi/js@7.4.47':
+    resolution: {integrity: sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==}
 
   '@miyaneee/rollup-plugin-json5@1.2.0':
     resolution: {integrity: sha512-JjTIaXZp9WzhUHpElrqPnl1AzBi/rvRs065F71+aTmlqvTMVkdbjZ8vfFl4nRlgJy+TPBw69ZK4pwFdmOAt4aA==}
@@ -7838,7 +7838,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@mdi/font@7.4.47': {}
+  '@mdi/js@7.4.47': {}
 
   '@miyaneee/rollup-plugin-json5@1.2.0(rollup@4.59.0)':
     dependencies:


### PR DESCRIPTION
## Summary

接續 PR4 的性能改善 — 把 Vuetify icon set 從 \`mdi-font\` 切到 \`mdi-svg\`,只 bundle 用到的 16 個 icon。

**⚠️ 此 PR base 為 \`perf/pr4-quick-wins\`(PR #9)** — PR4 merge 後,GitHub 會自動把 base 換成 master。

## 重大意外發現

當初預期是砍 403 KB 的 webfont。實際 build 出來 **`entry.css` 也從 573 KB 降到 250 KB(-323 KB)** — 原來 Tailwind 的 CSS 還內嵌了 7000+ 個 `.mdi-foo::before { content: "\Fxxxx" }` 規則(每個 MDI icon 一條)。完全是意外的大禮。

## 改動內容

### 套件
- 新增 \`@mdi/js@7.4.47\`(個別 icon path 常數,tree-shake friendly)
- 移除 \`@mdi/font@7.4.47\`(webfont 套件)

### Vuetify 設定
\`nuxt.config.ts\`:
\`\`\`ts
vuetifyOptions: {
  icons: { defaultSet: 'mdi-svg' }  // 從預設的 mdi-font 切過來
}
\`\`\`

### Syntax 遷移(20 個 v-icon 引用)
| 改前 | 改後 |
|---|---|
| \`<v-icon icon="mdi-menu">\` | \`<v-icon :icon="mdiMenu">\` |
| \`prepend-icon="mdi-heart-outline"\` | \`:prepend-icon="mdiHeartOutline"\` |

各檔案需要的 \`import { mdiX } from '@mdi/js'\`:

| 檔案 | icons |
|---|---|
| \`layouts/default.vue\` | mdiHeartOutline, mdiHeadQuestionOutline, mdiMessageAlertOutline, mdiAccountGroup, mdiVolumeHigh, mdiVolumeLow, mdiBrightness2, mdiTranslate |
| \`components/VoiceBtn.vue\` | mdiMenu, mdiHeartMinus, mdiHeartPlus, mdiYoutube, mdiDownload |
| \`pages/challenge.vue\` | mdiCheckCircle, mdiCloseCircle |
| \`pages/index.vue\` | mdiLink |
| \`pages/member.vue\` | mdiLink |

**共 16 個 unique icons,total bundled ~5 KB SVG paths。**

## 實測 size delta

| 資源 | PR4 結束時 | PR5 後 | 變化 |
|---|---|---|---|
| `entry.css` | 573 KB | **250 KB** | **-323 KB** |
| `materialdesignicons-webfont.*` | 403 KB | **0**(完全消失) | **-403 KB** |
| `<v-icon>` 渲染 | 字體字符 | inline SVG | DOM 變大但無 FOIT/FOUT |

**累積首屏 transfer 省 (PR4+PR5):~1.7 MB**
- banner.jpg: -741 KB(WebP + srcset)
- woman.png: -242 KB(WebP + lazy)
- entry.css: -327 KB(Tailwind preflight + MDI rules)
- MDI woff2: -403 KB(SVG inline)

## Test plan

- [x] \`npx nuxi generate\` 成功,0 link checker 錯誤
- [x] `.output/public` 內 \`grep materialdesignicons\` 完全沒有結果
- [x] `index.html` 含 124 個 inline SVG icons
- [x] entry.css 從 573 KB 降到 250 KB
- [ ] Vercel deploy preview:
  - [ ] 側欄 5 個導覽 icon 正常顯示
  - [ ] VoiceBtn 的 menu / 心 / YouTube / download icon 正常
  - [ ] 音量、夜間模式、語言切換 icon 正常
  - [ ] /challenge 的 ✓ / ✗ icon 正常
  - [ ] 任何頁面的 link icon 正常
- [ ] PageSpeed Insights 重跑,desktop 預期 90+,mobile 80+

🤖 Generated with [Claude Code](https://claude.com/claude-code)