### PR TITLE
perf(cls): PR6 — reserve layout space via critical CSS

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -181,6 +181,8 @@ const theme = useTheme();
 const { t, setLocale } = useI18n();
 const localePath = useLocalePath();
 
+// drawer 初始 false (SSG 友善,所有 client 一致);桌面在 onMounted 才打開
+// 桌面 v-main 的 256px 空間由 critical CSS @media 預留,所以 onMounted 開 drawer 不會造成 CLS
 const drawer = ref(false);
 const volume = ref(settings.volume);
 
@@ -210,6 +212,7 @@ onMounted(() => {
   updateVh();
   window.addEventListener('resize', updateVh);
 
+  // 桌面打開 drawer (256px 空間已由 critical CSS @media 預留,不會觸發 CLS)
   if (window.innerWidth >= 1024) {
     drawer.value = true;
   }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -169,6 +169,15 @@ export default defineNuxtConfig({
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },
         { name: 'theme-color', content: '#bd133d' }
       ],
+      // Critical CSS:在 entry.css 載入前就預留 v-app-bar (48px) 與 v-navigation-drawer (256px)
+      // 的空間,避免 hydration 時 v-main 位移造成 CLS。
+      // - 預設 (mobile):只 reserve toolbar 高度,不 reserve drawer (mobile 為 temporary overlay)
+      // - 桌面 (>=1024px):額外 reserve drawer 寬度 256px
+      style: [
+        {
+          innerHTML: `.v-main{padding-top:48px!important}@media (min-width:1024px){.v-main{padding-left:256px!important}}`
+        }
+      ],
       link: [
         { rel: 'apple-touch-icon', sizes: '180x180', href: '/apple-touch-icon.png' },
         { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/favicon-32x32.png' },


### PR DESCRIPTION
## Summary

PSI 報告 desktop **CLS 0.386**(致命)。Browser-verified 後實際抓到位移源頭:

```
v-main: (x=100, y=0, w=1200) → (x=256, y=48, w=1144)
       dx=156px (drawer 預留空間)
       dy=48px  (toolbar 高度)
```

Vuetify 的 \`--v-layout-top\` / \`--v-layout-left\` 是 hydration 後才 client-side 計算,SSR HTML 的 v-main inline style 是 top:0 left:0。entry.css 載入前的初次繪製就已經位置錯位。

## 修法

在 \`nuxt.config app.head.style\` 內 inline critical CSS,預留 toolbar + drawer 空間:

\`\`\`css
.v-main { padding-top: 48px !important; }
@media (min-width: 1024px) {
  .v-main { padding-left: 256px !important; }
}
\`\`\`

drawer state 邏輯維持原本(SSR 關、desktop onMounted 開),因為空間已由 @media 預留,drawer 後續打開不會位移。

## Browser-verified 結果

| 環境 | 之前 PSI | local 修後 |
|---|---|---|
| Desktop CLS | **0.386 ❌** | **0.012 ✅** (-97%) |
| Mobile CLS | 0.058 | **0.000 ✅** |
| 渲染視覺 | OK | OK(無視覺差異) |
| Console | OK | 0 errors |

5 次 build → preview → run 一致。

## 嘗試過的失敗路徑

- 設 \`vuetify.ssr.clientWidth: 1280\` 讓 SSR 假設 desktop:mobile 會在 hydration 後從假 desktop 跳回真 mobile,**CLS 變 0.948**。改用純 CSS @media 避開此陷阱。
- 在 default.vue 加 \`.v-main { --v-layout-top: 48px !important }\`:CSS 變數無法用 !important 蓋過 inline style,無效。

## Test plan

- [x] \`npx nuxi generate\` 0 errors
- [x] Browse desktop viewport(1400x900):CLS 0.012(5 runs 一致)
- [x] Browse mobile viewport(375x812):CLS 0.000
- [x] 視覺檢查:drawer 桌面展開、mobile 收合、hamburger 點擊可開合
- [x] Console 0 errors
- [ ] Vercel deploy preview → 跑 PSI,預期 desktop perf 56 → 80+

## 預期影響

CLS 是 Lighthouse perf 計分的高權重項。0.386 → 0.012 應該讓 desktop perf 從 56 顯著上升。如果其他指標(TBT/FCP)不變,perf score 預期跳到 80+。Mobile 也會跟著漂亮一點。

🤖 Generated with [Claude Code](https://claude.com/claude-code)