### PR TITLE
a11y(pr7): fix VoiceBtn aria-label + icon button names + ARIA hierarchy

### DIFF
--- a/app/components/VoiceBtn.vue
+++ b/app/components/VoiceBtn.vue
@@ -121,9 +121,19 @@ const twe_para = {
 // 計算屬性
 const computedButtonId = computed(() => props.buttonId || props.voiceId);
 
+// 從 default slot 萃取純文字 (給 aria-label 用)
+// 原本寫法 `vnodes.join('')` 會把 VNode 物件變成字串 "[object Object]",造成 a11y 失敗
+function extractText(input) {
+  if (input == null) return '';
+  if (typeof input === 'string' || typeof input === 'number') return String(input);
+  if (Array.isArray(input)) return input.map(extractText).join('');
+  if (typeof input === 'object') return extractText(input.children);
+  return '';
+}
+
 const slotText = computed(() => {
   const vnodes = slots.default?.() || [];
-  return vnodes.join('').trim();
+  return extractText(vnodes).trim();
 });
 
 const in_favorite = computed(() => favoriteStore.isFavorite(props.voiceId));

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app>
-    <v-navigation-drawer v-model="drawer" :mobile-breakpoint="1024" class="elevation-3">
-      <v-list style="padding-top: 0">
+    <v-navigation-drawer v-model="drawer" :mobile-breakpoint="1024" class="elevation-3" tag="nav">
+      <v-list style="padding-top: 0" role="none">
         <v-list-item :to="localePath('/')" exact>
           <template #prepend>
             <v-img alt="home-icon" src="/icon.png" width="24" class="mr-8" />
@@ -36,7 +36,7 @@
       </v-list>
       <v-divider></v-divider>
 
-      <v-list>
+      <v-list role="none">
         <v-list-item
           v-for="(item, i) in navigatorItems"
           :key="i"
@@ -67,13 +67,17 @@
     </v-navigation-drawer>
 
     <v-app-bar class="text-white" color="primary" density="compact">
-      <v-app-bar-nav-icon variant="text" @click.stop="drawer = !drawer"></v-app-bar-nav-icon>
+      <v-app-bar-nav-icon
+        variant="text"
+        :aria-label="$t('site.switch_menu')"
+        @click.stop="drawer = !drawer"
+      ></v-app-bar-nav-icon>
       <v-toolbar-title>{{ $t('site.title') }}</v-toolbar-title>
       <v-spacer></v-spacer>
 
       <v-menu :close-on-content-click="false">
         <template #activator="{ props }">
-          <v-btn icon variant="plain" v-bind="props">
+          <v-btn icon variant="plain" :aria-label="$t('control.volume')" v-bind="props">
             <v-icon :icon="mdiVolumeHigh"></v-icon>
           </v-btn>
         </template>
@@ -86,6 +90,7 @@
             hide-details
             track-color="#bdbdbd"
             color="#ff8a80"
+            :aria-label="$t('control.volume')"
             @update:model-value="onVolumeChange"
           ></v-slider>
           <v-icon :icon="mdiVolumeHigh" color="primary" class="ml-2"></v-icon>
@@ -94,7 +99,13 @@
 
       <v-tooltip location="bottom">
         <template #activator="{ props }">
-          <v-btn icon variant="plain" v-bind="props" @click="toggleTheme">
+          <v-btn
+            icon
+            variant="plain"
+            :aria-label="$t('site.switch_dark_mode')"
+            v-bind="props"
+            @click="toggleTheme"
+          >
             <v-icon :icon="mdiBrightness2"></v-icon>
           </v-btn>
         </template>
@@ -105,7 +116,12 @@
         <template #activator="{ props: menuProps }">
           <v-tooltip location="bottom">
             <template #activator="{ props: tooltipProps }">
-              <v-btn icon variant="plain" v-bind="mergeProps(menuProps, tooltipProps)">
+              <v-btn
+                icon
+                variant="plain"
+                :aria-label="$t('site.switch_language')"
+                v-bind="mergeProps(menuProps, tooltipProps)"
+              >
                 <v-icon :icon="mdiTranslate"></v-icon>
               </v-btn>
             </template>

--- a/i18n/locales/default.json
+++ b/i18n/locales/default.json
@@ -56,7 +56,8 @@
     "random": "隨機撥放",
     "repeat": "重複播放",
     "self": "播放控制",
-    "stop": "停止"
+    "stop": "停止",
+    "volume": "音量"
   },
   "member": {
     "error_authorization_required": "Discord帳號未連結或連結已過期。",
@@ -109,6 +110,7 @@
     "source": "來源",
     "switch_dark_mode": "夜間模式開關",
     "switch_language": "切換語言",
+    "switch_menu": "切換選單",
     "title": "灰妲語音博物館",
     "url": "https://dada-vtuber-button.vercel.app",
     "voice": "語音"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -56,7 +56,8 @@
     "random": "Random Mode",
     "repeat": "Repeat Mode",
     "self": "Player Control",
-    "stop": "Stop Playing"
+    "stop": "Stop Playing",
+    "volume": "Volume"
   },
   "member": {
     "error_authorization_required": "Discord account link has expired.",
@@ -109,6 +110,7 @@
     "source": "Source",
     "switch_dark_mode": "Dark Mode",
     "switch_language": "Switch Language",
+    "switch_menu": "Toggle Menu",
     "title": "DaDa Voice Museum",
     "url": "https://dada-vtuber-button.vercel.app",
     "voice": "Voice"

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -56,7 +56,8 @@
     "random": "自動ランダム再生",
     "repeat": "ループ",
     "self": "コントロール",
-    "stop": "再生停止"
+    "stop": "再生停止",
+    "volume": "音量"
   },
   "member": {
     "error_authorization_required": "Discordアカウントのリンクが期限切れです。",
@@ -109,6 +110,7 @@
     "source": "ソース",
     "switch_dark_mode": "ナイトモードスイッチ",
     "switch_language": "言語を切り替える",
+    "switch_menu": "メニュー切り替え",
     "title": "灰妲ボイス博物館",
     "url": "https://dada-vtuber-button.vercel.app",
     "voice": "音声"


### PR DESCRIPTION
## Summary

PSI 報告三項 a11y 失敗,browser-verified 後逐項修復。預期 a11y 分數:行動 90 → 100,桌面 85 → 100。

## 修復項目

### 1. 937 個 VoiceBtn 的 \`aria-label\` 全部是 \"[object Object]\"

**原因:** \`VoiceBtn.vue\` 的 \`slotText\` 用 \`vnodes.join('')\`,Vue VNode 物件被字串化成 \`[object Object]\`。

**修法:** 改寫成遞迴 \`extractText\` 從 VNode \`children\` 萃取純文字:
\`\`\`js
function extractText(input) {
  if (input == null) return '';
  if (typeof input === 'string' || typeof input === 'number') return String(input);
  if (Array.isArray(input)) return input.map(extractText).join('');
  if (typeof input === 'object') return extractText(input.children);
  return '';
}
\`\`\`

修後:
| 語音 | 修前 | 修後 |
|---|---|---|
| 天老爺阿 | \`aria-label=\"[object Object]\"\` | \`aria-label=\"天老爺阿\"\` |
| 能有多糟呢 | 同上 | \`能有多糟呢\` |
| (其他 935 個) | 同上 | 各自描述文字 |

### 2. Nav bar 4 個 icon button 沒有 accessible name

**原因:** hamburger / 音量 / 夜間模式 / 翻譯 button 只有 v-icon 沒文字,且沒設 \`aria-label\`。tooltip 雖然有文字但跟 button 沒透過 \`aria-describedby\` 關聯。

**修法:** 直接給 v-btn 加 \`:aria-label\`,文字從 i18n 帶:
- hamburger: \`site.switch_menu\` (新 key)
- volume: \`control.volume\` (新 key)
- dark mode: \`site.switch_dark_mode\` (既有)
- translate: \`site.switch_language\` (既有)

三語系都加了對應翻譯。

### 3. \`v-list role=\"list\"\` 內含 \`role=\"link\"\` (應為 listitem)

**原因:** Vuetify \`v-list-item\` 用 \`to\` / \`href\` 時 render 成 \`<a>\` 自帶 \`role=link\`,但父層 \`v-list\` 用 \`role=list\` 預期 \`listitem\` 子節點。ARIA 階層違規。

**修法:** 
- \`v-list\` 加 \`role=\"none\"\` 取消 list semantic,讓內部 link 直接被 AT 解讀
- \`v-navigation-drawer\` 加 \`tag=\"nav\"\`,語意更精準(這個 drawer 確實是導覽列)

## Browser-verified 結果

| 檢查項 | 修前 | 修後 |
|---|---|---|
| VoiceBtn \`aria-label\` 為 \`[object Object]\` | 937 個 | **0** |
| Button 無 accessible name | 4 個 | **0** |
| \`role=list\` 階層違規 | 2 個 | **0** |
| Console errors | 0 | 0 |
| 視覺渲染 | OK | OK(無變動) |

## Test plan

- [x] \`npx nuxi generate\` 0 errors
- [x] Browse:VoiceBtn \`aria-label\` 5 個 sample 都對
- [x] Browse:0 個 nameless buttons
- [x] Browse:0 個 ARIA list hierarchy violations
- [x] Browse:Console 0 errors
- [x] Visual:desktop / mobile 渲染未變動
- [ ] Vercel deploy preview → PSI 重跑,預期 a11y 100/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)