### PR TITLE
feat(random): PR12 — random play button next to search bar

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -17,6 +17,8 @@
         <v-btn
           :prepend-icon="mdiShuffle"
           :aria-label="$t('control.random')"
+          :loading="isRandomLoading"
+          :disabled="isRandomLoading"
           color="primary"
           variant="tonal"
           rounded="lg"
@@ -125,6 +127,12 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <!-- 隨機播放專用 snackbar:由 audio onStart/onEnd 控制顯隱,
+         timeout=-1 表示不自動消失 (audio ended/error 時才隱藏) -->
+    <v-snackbar v-model="showRandomSnackbar" :timeout="-1" location="top" color="success" elevation="6">
+      {{ randomSnackbarText }}
+    </v-snackbar>
   </v-container>
 </template>
 
@@ -153,6 +161,11 @@ const is_dialog_open = ref(false);
 const dialog_item = ref({ description: {}, url: '' });
 
 const selectedYear = ref('All');
+
+// 隨機播放按鈕 loading state + 自製 snackbar (由 audio 事件控制,不用全域 useSnackbar)
+const isRandomLoading = ref(false);
+const showRandomSnackbar = ref(false);
+const randomSnackbarText = ref('');
 
 // 搜尋分兩個 ref:input 給 v-model 即時更新 (responsive UI),
 // query 是 debounced 過的值,觸發 voice list filter (~200ms 後才重新算)
@@ -303,14 +316,46 @@ const play = item => {
 
 // 全域隨機:不受搜尋/年份 filter 影響,從所有 voices 挑一個 (使用者選 A)
 // pickRandomVoice util 從 app/utils/pickRandomVoice.ts auto-import
-// 播放後彈 snackbar 顯示「播放中:類別 - 名稱」讓使用者知道隨機到什麼
+//
+// 流程:
+// 1. 按下按鈕 → isRandomLoading=true (button 進入 loading,disabled 防連點)
+// 2. audio canplay 事件 → onStart → 彈 snackbar (時間點是「真的開始播」而非「按下去」)
+// 3. audio ended/error → onEnd/onError → loading=false + snackbar 收起
+//    (snackbar timeout=-1,只靠這裡控制,跟著音檔長度顯示)
 const play_random_voice = () => {
   const pick = pickRandomVoice(voice_lists.value.groups);
   if (!pick) return;
-  play(pick.voice);
+
+  isRandomLoading.value = true;
+  showRandomSnackbar.value = false; // 收掉前一個 snackbar (若有)
+
   const groupName = pick.group.group_description?.[current_locale.value] || pick.group.group_name || '';
   const voiceText = pick.voice.description?.[current_locale.value] || pick.voice.description?.zh || pick.voice.name;
-  snackbar.show(t('action.now_playing', { group: groupName, voice: voiceText }));
+  const snackbarText = t('action.now_playing', { group: groupName, voice: voiceText });
+
+  audioStore.play(
+    pick.voice,
+    voice_host.value,
+    pick.voice.description?.[current_locale.value] || pick.voice.name,
+    t('control.full_name'),
+    t('site.title'),
+    play_random_voice, // onRandomNext (audio store 隨機模式 hook,目前無 UI 切換)
+    {
+      onStart: () => {
+        randomSnackbarText.value = snackbarText;
+        showRandomSnackbar.value = true;
+      },
+      onEnd: () => {
+        isRandomLoading.value = false;
+        showRandomSnackbar.value = false;
+      },
+      onError: () => {
+        isRandomLoading.value = false;
+        showRandomSnackbar.value = false;
+      }
+    }
+  );
+  send_google_event(pick.voice);
 };
 
 const stop_all = () => audioStore.stopAll();

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -15,13 +15,17 @@
           @update:model-value="v => (searchInput = v ?? '')"
         ></v-text-field>
         <v-btn
-          :icon="mdiShuffle"
+          :prepend-icon="mdiShuffle"
           :aria-label="$t('control.random')"
           color="primary"
           variant="tonal"
-          size="large"
+          rounded="lg"
+          height="48"
+          class="text-none"
           @click="play_random_voice"
-        ></v-btn>
+        >
+          {{ $t('control.random') }}
+        </v-btn>
       </div>
 
       <div class="d-flex mb-4">
@@ -299,9 +303,14 @@ const play = item => {
 
 // 全域隨機:不受搜尋/年份 filter 影響,從所有 voices 挑一個 (使用者選 A)
 // pickRandomVoice util 從 app/utils/pickRandomVoice.ts auto-import
+// 播放後彈 snackbar 顯示「播放中:類別 - 名稱」讓使用者知道隨機到什麼
 const play_random_voice = () => {
-  const random_item = pickRandomVoice(voice_lists.value.groups);
-  if (random_item) play(random_item);
+  const pick = pickRandomVoice(voice_lists.value.groups);
+  if (!pick) return;
+  play(pick.voice);
+  const groupName = pick.group.group_description?.[current_locale.value] || pick.group.group_name || '';
+  const voiceText = pick.voice.description?.[current_locale.value] || pick.voice.description?.zh || pick.voice.name;
+  snackbar.show(t('action.now_playing', { group: groupName, voice: voiceText }));
 };
 
 const stop_all = () => audioStore.stopAll();

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -20,7 +20,6 @@
           :loading="isRandomLoading"
           :disabled="isRandomLoading"
           color="primary"
-          variant="tonal"
           rounded="lg"
           height="48"
           class="text-none"

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,18 +1,28 @@
 <template>
   <v-container class="d-flex flex-column align-center px-0 pt-0" fluid>
     <v-col cols="12" class="pa-0" style="min-width: 85%">
-      <v-text-field
-        :model-value="searchInput"
-        :placeholder="$t('search.placeholder')"
-        :aria-label="$t('search.placeholder')"
-        :prepend-inner-icon="mdiMagnify"
-        :clearable="true"
-        variant="outlined"
-        density="comfortable"
-        hide-details
-        class="mb-4"
-        @update:model-value="v => (searchInput = v ?? '')"
-      ></v-text-field>
+      <div class="d-flex align-center mb-4 gap-2">
+        <v-text-field
+          :model-value="searchInput"
+          :placeholder="$t('search.placeholder')"
+          :aria-label="$t('search.placeholder')"
+          :prepend-inner-icon="mdiMagnify"
+          :clearable="true"
+          variant="outlined"
+          density="comfortable"
+          hide-details
+          class="flex-grow-1"
+          @update:model-value="v => (searchInput = v ?? '')"
+        ></v-text-field>
+        <v-btn
+          :icon="mdiShuffle"
+          :aria-label="$t('control.random')"
+          color="primary"
+          variant="tonal"
+          size="large"
+          @click="play_random_voice"
+        ></v-btn>
+      </div>
 
       <div class="d-flex mb-4">
         <v-chip-group v-model="selectedYear" mandatory selected-class="selected-year">
@@ -116,7 +126,7 @@
 
 <script setup>
 import { ref, computed, watch, onMounted, nextTick } from 'vue';
-import { mdiLink, mdiMagnify } from '@mdi/js';
+import { mdiLink, mdiMagnify, mdiShuffle } from '@mdi/js';
 
 // voices.json (~500KB) 改走 /api/voices server route,不再內聯進 client JS bundle
 // SSG prerender: server route 用 import 讀檔 → useAsyncData 結果寫入 _payload.json
@@ -287,12 +297,11 @@ const play = item => {
   send_google_event(item);
 };
 
-const get_random_int = max => Math.floor(Math.random() * Math.floor(max));
-
+// 全域隨機:不受搜尋/年份 filter 影響,從所有 voices 挑一個 (使用者選 A)
+// pickRandomVoice util 從 app/utils/pickRandomVoice.ts auto-import
 const play_random_voice = () => {
-  const random_list = groups.value[get_random_int(groups.value.length)];
-  const random_item = random_list.voice_list[get_random_int(random_list.voice_list.length)];
-  play(random_item);
+  const random_item = pickRandomVoice(voice_lists.value.groups);
+  if (random_item) play(random_item);
 };
 
 const stop_all = () => audioStore.stopAll();

--- a/app/stores/audio.ts
+++ b/app/stores/audio.ts
@@ -26,7 +26,8 @@ export const useAudioStore = defineStore('audio', {
       metaTitle: string,
       fullTitle: string,
       albumTitle: string,
-      onRandomNext?: () => void
+      onRandomNext?: () => void,
+      callbacks?: { onStart?: () => void; onEnd?: () => void; onError?: () => void }
     ) {
       const settings = useSettingsStore();
       const audioUrl = voiceHost + item.path;
@@ -50,11 +51,18 @@ export const useAudioStore = defineStore('audio', {
         navigator.mediaSession.playbackState = 'playing';
       }
 
+      // 兩種「結束」狀態都要呼叫 onEnd:正常結束 + paused (stopAll 觸發)
+      // 用 flag 避免 onStart 失敗、onEnd 仍被呼叫等矛盾狀態
+      let started = false;
       const cleanup = () => {
         this.progressMap[item.id] = 0;
         this.playingMap[item.id] = false;
         clearInterval(this.timers[item.id]);
         this.activeAudios.delete(audio);
+        if (started) {
+          started = false;
+          callbacks?.onEnd?.();
+        }
       };
 
       audio.addEventListener('canplay', () => {
@@ -62,6 +70,8 @@ export const useAudioStore = defineStore('audio', {
         audio.play();
         this.activeAudios.add(audio);
         this.playingMap[item.id] = true;
+        started = true;
+        callbacks?.onStart?.();
 
         // 設定進度條計時器
         clearInterval(this.timers[item.id]);
@@ -91,6 +101,7 @@ export const useAudioStore = defineStore('audio', {
 
       audio.addEventListener('error', () => {
         cleanup();
+        callbacks?.onError?.();
         const { $i18n } = useNuxtApp();
         useSnackbar().show($i18n.t('action.audio_error'));
       });

--- a/app/utils/pickRandomVoice.ts
+++ b/app/utils/pickRandomVoice.ts
@@ -1,17 +1,26 @@
-// 從 voice groups 隨機挑一個 voice
+// 從 voice groups 隨機挑一個 voice,回傳 { group, voice }
 // 抽到 util 是為了 (1) 可 unit test (mock Math.random) (2) 邏輯集中
+//
+// 回傳含 group 是為了讓呼叫端可以顯示「播放中:類別 - 名稱」之類 UI feedback
 //
 // 使用兩段隨機:先選 group 再選 voice。注意這「不是」純粹的均勻隨機 —
 // 小群組裡的 voice 被選中機率比大群組裡的高。但語意上「先挑類別再挑語音」
 // 對使用者來說更有變化,實務上 acceptable trade-off。
 
-type Voice = { id: string; name: string; [key: string]: any };
-type VoiceGroup = { voice_list: Voice[]; [key: string]: any };
+type Voice = { id: string; name: string; description?: { zh?: string; ja?: string; en?: string }; [key: string]: any };
+type VoiceGroup = {
+  voice_list: Voice[];
+  group_name?: string;
+  group_description?: { zh?: string; ja?: string; en?: string };
+  [key: string]: any;
+};
+
+export type RandomPick = { group: VoiceGroup; voice: Voice };
 
 export function pickRandomVoice(
   groups: VoiceGroup[] | undefined | null,
   rng: () => number = Math.random
-): Voice | null {
+): RandomPick | null {
   if (!groups?.length) return null;
 
   // 過濾掉空群組,避免選到空 voice_list 噴錯
@@ -19,5 +28,6 @@ export function pickRandomVoice(
   if (!nonEmpty.length) return null;
 
   const group = nonEmpty[Math.floor(rng() * nonEmpty.length)];
-  return group.voice_list[Math.floor(rng() * group.voice_list.length)];
+  const voice = group.voice_list[Math.floor(rng() * group.voice_list.length)];
+  return { group, voice };
 }

--- a/app/utils/pickRandomVoice.ts
+++ b/app/utils/pickRandomVoice.ts
@@ -1,0 +1,23 @@
+// 從 voice groups 隨機挑一個 voice
+// 抽到 util 是為了 (1) 可 unit test (mock Math.random) (2) 邏輯集中
+//
+// 使用兩段隨機:先選 group 再選 voice。注意這「不是」純粹的均勻隨機 —
+// 小群組裡的 voice 被選中機率比大群組裡的高。但語意上「先挑類別再挑語音」
+// 對使用者來說更有變化,實務上 acceptable trade-off。
+
+type Voice = { id: string; name: string; [key: string]: any };
+type VoiceGroup = { voice_list: Voice[]; [key: string]: any };
+
+export function pickRandomVoice(
+  groups: VoiceGroup[] | undefined | null,
+  rng: () => number = Math.random
+): Voice | null {
+  if (!groups?.length) return null;
+
+  // 過濾掉空群組,避免選到空 voice_list 噴錯
+  const nonEmpty = groups.filter(g => g?.voice_list?.length);
+  if (!nonEmpty.length) return null;
+
+  const group = nonEmpty[Math.floor(rng() * nonEmpty.length)];
+  return group.voice_list[Math.floor(rng() * group.voice_list.length)];
+}

--- a/i18n/locales/default.json
+++ b/i18n/locales/default.json
@@ -5,6 +5,7 @@
     "download": "下載語音",
     "like": "加入最愛",
     "like_success": "已加入最愛",
+    "now_playing": "播放中:{group} - {voice}",
     "play_option": "播放選項",
     "show_less": "顯示較少",
     "show_more": "顯示更多",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -5,6 +5,7 @@
     "download": "Download",
     "like": "Like",
     "like_success": "Liked",
+    "now_playing": "Playing: {group} - {voice}",
     "play_option": "Play Option",
     "show_less": "Show Less",
     "show_more": "Show More",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -5,6 +5,7 @@
     "download": "ダウンロード",
     "like": "お気に入り",
     "like_success": "お気に入り登録済み",
+    "now_playing": "再生中:{group} - {voice}",
     "play_option": "再生オプション",
     "show_less": "もっと少なく表示",
     "show_more": "もっと見る",

--- a/tests/e2e/flows.spec.ts
+++ b/tests/e2e/flows.spec.ts
@@ -66,39 +66,63 @@ test.describe('User flows', () => {
     await expect(page).toHaveURL(/\/ja\/?$/);
   });
 
-  test('random play button triggers audio playback + shows now_playing snackbar (PR12)', async ({ page }) => {
+  test('random play: button loading + snackbar on play start, both clear on end (PR12)', async ({ page }) => {
+    // 控制 canplay 觸發時機,讓我們能驗證:
+    // - 按下後到 canplay 之間 button 顯示 loading
+    // - canplay 之後 snackbar 才出現 (不是按下就出現)
+    // - audio ended 之後 button 退出 loading + snackbar 消失
     await page.addInitScript(() => {
       (window as any).__audioPlayCalls = [];
+      (window as any).__audioElements = [];
       HTMLAudioElement.prototype.play = function () {
         (window as any).__audioPlayCalls.push(this.src);
         return Promise.resolve();
       };
       HTMLAudioElement.prototype.load = function () {
-        setTimeout(() => this.dispatchEvent(new Event('canplay')), 0);
+        (window as any).__audioElements.push(this);
+        // 不自動觸發 canplay,由 test 手動觸發
       };
     });
 
     await page.goto('/');
     await page.waitForLoadState('networkidle');
 
-    await page.locator('button[aria-label="隨機撥放"]').click();
+    const randomBtn = page.locator('button[aria-label="隨機撥放"]');
+    await randomBtn.click();
 
-    await expect
-      .poll(async () => (await page.evaluate(() => (window as any).__audioPlayCalls?.length || 0)) > 0, {
-        timeout: 3000,
-        intervals: [100, 200, 500]
-      })
-      .toBe(true);
+    // 按下後 button 應該 loading (v-btn loading class)
+    await expect(randomBtn).toHaveClass(/v-btn--loading/);
+    // snackbar 還沒出現 (因為 canplay 還沒觸發)
+    await expect(page.locator('.v-snackbar--active')).toHaveCount(0);
 
+    // 模擬 canplay 觸發
+    await page.evaluate(() => {
+      const audios = (window as any).__audioElements;
+      audios[audios.length - 1]?.dispatchEvent(new Event('canplay'));
+    });
+
+    // 現在 snackbar 應該出現,含「播放中」
+    await expect(page.locator('.v-snackbar--active')).toContainText('播放中');
+
+    // 模擬 audio ended
+    await page.evaluate(() => {
+      const audios = (window as any).__audioElements;
+      audios[audios.length - 1]?.dispatchEvent(new Event('ended'));
+    });
+
+    // button loading 退出, snackbar 消失
+    await expect(randomBtn).not.toHaveClass(/v-btn--loading/);
+    await expect(page.locator('.v-snackbar--active')).toHaveCount(0);
+
+    // 確認 audio.play() 真的被呼叫過
     const calls = await page.evaluate(() => (window as any).__audioPlayCalls || []);
     expect(calls[0]).toMatch(/\.mp3$/);
-
-    // 應該彈出 "播放中:<group> - <voice>" snackbar
-    await expect(page.locator('.v-snackbar')).toContainText('播放中');
   });
 
   test('random play uses ALL voices, not filter-restricted (PR12)', async ({ page }) => {
     // 即使搜尋過濾掉大部分,隨機按鈕應該還是從全部 937 條挑
+    // 注意:按鈕現在有 loading state,要 audio ended 才能再點下一次,
+    // 所以 mock load() 立即觸發 canplay 後再觸發 ended 模擬「瞬間播完」
     await page.addInitScript(() => {
       (window as any).__audioPlayCalls = [];
       HTMLAudioElement.prototype.play = function () {
@@ -106,7 +130,11 @@ test.describe('User flows', () => {
         return Promise.resolve();
       };
       HTMLAudioElement.prototype.load = function () {
-        setTimeout(() => this.dispatchEvent(new Event('canplay')), 0);
+        setTimeout(() => {
+          this.dispatchEvent(new Event('canplay'));
+          // 立即觸發 ended,模擬瞬間播完,讓 button loading 解除
+          setTimeout(() => this.dispatchEvent(new Event('ended')), 5);
+        }, 0);
       };
     });
 
@@ -117,15 +145,18 @@ test.describe('User flows', () => {
     await page.locator('input[placeholder*="搜尋"]').fill('天老爺');
     await page.waitForTimeout(400);
 
-    // 連點隨機 10 次,應該至少有一次播到非"天老爺..."(即超出 filter 範圍)
-    const playedUrls = new Set<string>();
+    const randomBtn = page.locator('button[aria-label="隨機撥放"]');
+
+    // 連點隨機 10 次 (等 button loading 解除才能點下一次)
     for (let i = 0; i < 10; i++) {
-      await page.locator('button[aria-label="隨機撥放"]').click();
-      await page.waitForTimeout(50);
+      await expect(randomBtn).not.toHaveClass(/v-btn--loading/, { timeout: 1000 });
+      await randomBtn.click();
+      await page.waitForTimeout(30);
     }
+    await page.waitForTimeout(100);
     const calls = await page.evaluate(() => (window as any).__audioPlayCalls || []);
     expect(calls.length).toBeGreaterThanOrEqual(10);
-    calls.forEach((u: string) => playedUrls.add(u));
+    const playedUrls = new Set<string>(calls);
     // 10 次播放在 937 條池子裡,撞同一個的機率極低 (碰撞 ≈ 10²/937 ≈ 1%)
     // 至少要有 5 種不同的 URL 才合理 (容許一點重複)
     expect(playedUrls.size).toBeGreaterThanOrEqual(5);

--- a/tests/e2e/flows.spec.ts
+++ b/tests/e2e/flows.spec.ts
@@ -66,7 +66,7 @@ test.describe('User flows', () => {
     await expect(page).toHaveURL(/\/ja\/?$/);
   });
 
-  test('random play button triggers audio playback (PR12)', async ({ page }) => {
+  test('random play button triggers audio playback + shows now_playing snackbar (PR12)', async ({ page }) => {
     await page.addInitScript(() => {
       (window as any).__audioPlayCalls = [];
       HTMLAudioElement.prototype.play = function () {
@@ -92,6 +92,9 @@ test.describe('User flows', () => {
 
     const calls = await page.evaluate(() => (window as any).__audioPlayCalls || []);
     expect(calls[0]).toMatch(/\.mp3$/);
+
+    // 應該彈出 "播放中:<group> - <voice>" snackbar
+    await expect(page.locator('.v-snackbar')).toContainText('播放中');
   });
 
   test('random play uses ALL voices, not filter-restricted (PR12)', async ({ page }) => {

--- a/tests/e2e/flows.spec.ts
+++ b/tests/e2e/flows.spec.ts
@@ -66,6 +66,68 @@ test.describe('User flows', () => {
     await expect(page).toHaveURL(/\/ja\/?$/);
   });
 
+  test('random play button triggers audio playback (PR12)', async ({ page }) => {
+    await page.addInitScript(() => {
+      (window as any).__audioPlayCalls = [];
+      HTMLAudioElement.prototype.play = function () {
+        (window as any).__audioPlayCalls.push(this.src);
+        return Promise.resolve();
+      };
+      HTMLAudioElement.prototype.load = function () {
+        setTimeout(() => this.dispatchEvent(new Event('canplay')), 0);
+      };
+    });
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await page.locator('button[aria-label="隨機撥放"]').click();
+
+    await expect
+      .poll(async () => (await page.evaluate(() => (window as any).__audioPlayCalls?.length || 0)) > 0, {
+        timeout: 3000,
+        intervals: [100, 200, 500]
+      })
+      .toBe(true);
+
+    const calls = await page.evaluate(() => (window as any).__audioPlayCalls || []);
+    expect(calls[0]).toMatch(/\.mp3$/);
+  });
+
+  test('random play uses ALL voices, not filter-restricted (PR12)', async ({ page }) => {
+    // 即使搜尋過濾掉大部分,隨機按鈕應該還是從全部 937 條挑
+    await page.addInitScript(() => {
+      (window as any).__audioPlayCalls = [];
+      HTMLAudioElement.prototype.play = function () {
+        (window as any).__audioPlayCalls.push(this.src);
+        return Promise.resolve();
+      };
+      HTMLAudioElement.prototype.load = function () {
+        setTimeout(() => this.dispatchEvent(new Event('canplay')), 0);
+      };
+    });
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // 搜尋一個只命中 1~2 個語音的字串
+    await page.locator('input[placeholder*="搜尋"]').fill('天老爺');
+    await page.waitForTimeout(400);
+
+    // 連點隨機 10 次,應該至少有一次播到非"天老爺..."(即超出 filter 範圍)
+    const playedUrls = new Set<string>();
+    for (let i = 0; i < 10; i++) {
+      await page.locator('button[aria-label="隨機撥放"]').click();
+      await page.waitForTimeout(50);
+    }
+    const calls = await page.evaluate(() => (window as any).__audioPlayCalls || []);
+    expect(calls.length).toBeGreaterThanOrEqual(10);
+    calls.forEach((u: string) => playedUrls.add(u));
+    // 10 次播放在 937 條池子裡,撞同一個的機率極低 (碰撞 ≈ 10²/937 ≈ 1%)
+    // 至少要有 5 種不同的 URL 才合理 (容許一點重複)
+    expect(playedUrls.size).toBeGreaterThanOrEqual(5);
+  });
+
   test('drawer toggles on hamburger click (mobile)', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto('/');

--- a/tests/unit/pickRandomVoice.test.ts
+++ b/tests/unit/pickRandomVoice.test.ts
@@ -31,27 +31,31 @@ describe('pickRandomVoice', () => {
       { group_name: 'empty', voice_list: [] },
       { group_name: 'one', voice_list: [{ id: 'only', name: 'only' }] }
     ];
-    // rng returns 0 → picks first non-empty group (idx 0 of filtered list = 'one')
     const result = pickRandomVoice(groups, () => 0);
-    expect(result?.id).toBe('only');
+    expect(result?.voice.id).toBe('only');
+    expect(result?.group.group_name).toBe('one');
   });
 
   it('picks deterministically with stubbed rng (low value)', () => {
     // rng=0 → group[0].voice_list[0]
-    expect(pickRandomVoice(fixture, () => 0)?.id).toBe('a1');
+    const result = pickRandomVoice(fixture, () => 0);
+    expect(result?.voice.id).toBe('a1');
+    expect(result?.group.group_name).toBe('a');
   });
 
   it('picks deterministically with stubbed rng (high value)', () => {
     // rng=0.99 → floor(0.99 * 2) = 1 → group[1], voice[0] ('b1', since only one voice)
-    expect(pickRandomVoice(fixture, () => 0.99)?.id).toBe('b1');
+    const result = pickRandomVoice(fixture, () => 0.99);
+    expect(result?.voice.id).toBe('b1');
+    expect(result?.group.group_name).toBe('b');
   });
 
-  it('returns a valid voice from the pool', () => {
-    // 跑 10 次,結果都應該在 pool 內
-    const validIds = new Set(['a1', 'a2', 'b1']);
-    for (let i = 0; i < 10; i++) {
+  it('returns matching group+voice pair (regression: group must contain returned voice)', () => {
+    for (let i = 0; i < 20; i++) {
       const result = pickRandomVoice(fixture);
-      expect(validIds.has(result?.id || '')).toBe(true);
+      expect(result).not.toBeNull();
+      // 群組裡必須真的有這個 voice (不能 group=a voice=b1 之類錯配)
+      expect(result!.group.voice_list.some(v => v.id === result!.voice.id)).toBe(true);
     }
   });
 });

--- a/tests/unit/pickRandomVoice.test.ts
+++ b/tests/unit/pickRandomVoice.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { pickRandomVoice } from '../../app/utils/pickRandomVoice';
+
+const fixture = [
+  {
+    group_name: 'a',
+    voice_list: [
+      { id: 'a1', name: 'a1' },
+      { id: 'a2', name: 'a2' }
+    ]
+  },
+  {
+    group_name: 'b',
+    voice_list: [{ id: 'b1', name: 'b1' }]
+  }
+];
+
+describe('pickRandomVoice', () => {
+  it('returns null for empty / nullish input', () => {
+    expect(pickRandomVoice(undefined)).toBeNull();
+    expect(pickRandomVoice(null)).toBeNull();
+    expect(pickRandomVoice([])).toBeNull();
+  });
+
+  it('returns null if all groups are empty', () => {
+    expect(pickRandomVoice([{ group_name: 'x', voice_list: [] }])).toBeNull();
+  });
+
+  it('skips empty groups', () => {
+    const groups = [
+      { group_name: 'empty', voice_list: [] },
+      { group_name: 'one', voice_list: [{ id: 'only', name: 'only' }] }
+    ];
+    // rng returns 0 → picks first non-empty group (idx 0 of filtered list = 'one')
+    const result = pickRandomVoice(groups, () => 0);
+    expect(result?.id).toBe('only');
+  });
+
+  it('picks deterministically with stubbed rng (low value)', () => {
+    // rng=0 → group[0].voice_list[0]
+    expect(pickRandomVoice(fixture, () => 0)?.id).toBe('a1');
+  });
+
+  it('picks deterministically with stubbed rng (high value)', () => {
+    // rng=0.99 → floor(0.99 * 2) = 1 → group[1], voice[0] ('b1', since only one voice)
+    expect(pickRandomVoice(fixture, () => 0.99)?.id).toBe('b1');
+  });
+
+  it('returns a valid voice from the pool', () => {
+    // 跑 10 次,結果都應該在 pool 內
+    const validIds = new Set(['a1', 'a2', 'b1']);
+    for (let i = 0; i < 10; i++) {
+      const result = pickRandomVoice(fixture);
+      expect(validIds.has(result?.id || '')).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

UX 分析中提過的「隨機播放」功能。在 search bar 右側放一個 shuffle icon button,點擊從全部 937 條語音隨機挑一個播放。

## 設計決策(使用者選的)

| Q | 選擇 | 理由 |
|---|---|---|
| 隨機範圍 | **全域**(不受 search/year filter) | 跟過濾解耦,可邊搜尋邊隨機探索 |
| 視覺指示 | **純播放**(不 auto scroll/expand) | 簡單,voice button 抖動已表示 playing |

我自己決定的:
- 位置:search bar 右側獨立 v-btn(不塞 append-inner 避免 icon 語意混淆)
- Icon:\`mdi-shuffle\`
- 樣式:\`variant=\"tonal\" color=\"primary\" size=\"large\"\`
- 沿用 i18n \`control.random\`「隨機撥放」(三語系都已有)

## 改動

- **新增 \`app/utils/pickRandomVoice.ts\`**:隨機 picker util,接受 \`rng\` 參數可 mock。邏輯「先選 group 再選 voice」(實務 trade-off:小群組裡 voice 被選機率較高,但變化豐富)
- **\`index.vue\`**:
  - search bar 包進 flex 容器,右側放 shuffle btn
  - \`play_random_voice\` 改用 \`voice_lists.value.groups\`(raw)而非 \`groups.value\`(filter 後)→ 全域隨機
  - 刪掉 inline \`get_random_int\`,改用 util

## Test

### Unit (vitest) × 6

- empty/nullish input → null
- 空群組自動過濾
- rng=0 / rng=0.99 邊界決定性測試
- 跑 10 次都在 valid pool 內

### E2E (playwright) × 2

1. \`random play button triggers audio playback\` — 點按鈕 → \`audio.play()\` 被呼叫 → URL \`.mp3\` 結尾
2. \`random play uses ALL voices, not filter-restricted\` — 搜尋「天老爺」後,連點隨機 10 次,**至少 5 個不同 URL**(驗證在 937 池子裡而非 filter 後 1~2 個)

## Local verify

- pnpm lint:        clean
- vitest run:       **27/27** (21 prior + 6 new)
- nuxi generate:    OK
- search.spec.ts:   5/5
- flows.spec.ts:    **7/7** (含 2 個新 random tests)

## ⚠️ 已知 pre-existing flake(非 PR12 造成)

Full E2E suite 偶有 1~3 個 test 失敗(每次不同):
- \`a11y: /favorite\` / \`a11y: /challenge\`
- \`flows: language switcher\`
- \`flows: challenge page can be started\`

從 PR10 testing infra 上線就在了,**跟 PR12 無關**。CI 的 \`retries: 1\` 會 mask 掉。需要單獨另開 PR 修(疑似 state leak / timing 問題)。

## Test plan

- [x] Unit 27/27
- [x] search.spec.ts 5/5
- [x] flows.spec.ts 7/7 (含 PR12 新測試)
- [x] Lint clean
- [x] SSR HTML 含 shuffle button
- [ ] Vercel deploy preview → 實機點隨機 + 配合搜尋驗證全域隨機

🤖 Generated with [Claude Code](https://claude.com/claude-code)