### PR TITLE
feat(soundboard): PR16 - 灰妲 Soundboard for streamers

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -171,6 +171,10 @@
           <NuxtLink :to="localePath('/privacy')" class="text-decoration-underline text-accent">{{
             $t('site.privacy')
           }}</NuxtLink>
+          <span>&nbsp;|&nbsp;</span>
+          <NuxtLink :to="localePath('/soundboard')" class="text-decoration-underline text-accent">{{
+            $t('soundboard.streamer_tool')
+          }}</NuxtLink>
         </div>
         <div class="text-center mt-1" v-html="footerContent"></div>
       </v-footer>

--- a/app/layouts/soundboard.vue
+++ b/app/layouts/soundboard.vue
@@ -1,0 +1,17 @@
+<template>
+  <!-- Minimal layout 給 /soundboard 用 — 沒 drawer / 沒 app-bar / 沒 footer
+       v-app 還是要保留,Vuetify 元件需要 theme provider。 -->
+  <v-app>
+    <v-main class="soundboard-main">
+      <slot />
+    </v-main>
+  </v-app>
+</template>
+
+<style scoped>
+.soundboard-main {
+  /* 蓋掉 critical CSS 的 padding-top: 48px (那是預設 layout 給 app-bar 留的空間) */
+  padding-top: 0 !important;
+  padding-left: 0 !important;
+}
+</style>

--- a/app/pages/soundboard.vue
+++ b/app/pages/soundboard.vue
@@ -445,7 +445,6 @@ useSeoMeta({
   transition:
     background-color 0.12s,
     border-color 0.12s;
-  max-width: 240px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/app/pages/soundboard.vue
+++ b/app/pages/soundboard.vue
@@ -1,0 +1,463 @@
+<template>
+  <div class="soundboard-root">
+    <!-- 行動裝置:顯示提示而非真正介面 -->
+    <div v-if="isMobile" class="d-flex align-center justify-center pa-6" style="min-height: 100vh">
+      <v-card variant="outlined" class="rounded-lg pa-6" max-width="480">
+        <div class="d-flex align-center ga-3 mb-3">
+          <v-icon :icon="mdiMonitor" size="large" color="primary"></v-icon>
+          <h2 class="text-h6 font-weight-bold ma-0">{{ $t('soundboard.mobile_hint_title') }}</h2>
+        </div>
+        <p class="text-body-2 mb-4 text-medium-emphasis">{{ $t('soundboard.mobile_hint_body') }}</p>
+        <v-btn :to="localePath('/')" :prepend-icon="mdiHome" color="primary" rounded="lg" class="text-none" block>
+          {{ $t('soundboard.back_to_home') }}
+        </v-btn>
+      </v-card>
+    </div>
+
+    <!-- 桌面 soundboard -->
+    <div v-else class="d-flex flex-column" style="min-height: 100vh">
+      <!-- Top bar:標題 + Overlap toggle + 回主站 -->
+      <header class="soundboard-topbar d-flex align-center px-4 py-2 ga-3">
+        <h1 class="text-h6 font-weight-bold ma-0">
+          <v-icon :icon="mdiVolumeHigh" class="me-2"></v-icon>{{ $t('soundboard.title') }}
+        </h1>
+        <span class="text-caption text-medium-emphasis d-none d-md-inline">{{ $t('soundboard.subtitle') }}</span>
+        <v-spacer></v-spacer>
+
+        <v-btn
+          :prepend-icon="mdiLayersTriple"
+          :variant="soundboard.overlap ? 'flat' : 'outlined'"
+          :color="soundboard.overlap ? 'primary' : ''"
+          rounded="lg"
+          size="small"
+          class="text-none"
+          :aria-pressed="soundboard.overlap"
+          :title="$t('soundboard.overlap_hint')"
+          @click="onToggleOverlap"
+        >
+          {{ $t('soundboard.overlap') }}
+        </v-btn>
+
+        <v-btn
+          :prepend-icon="mdiHome"
+          :to="localePath('/')"
+          variant="outlined"
+          rounded="lg"
+          size="small"
+          class="text-none"
+        >
+          {{ $t('soundboard.back_to_home') }}
+        </v-btn>
+      </header>
+
+      <v-divider></v-divider>
+
+      <!-- 9 個快捷鍵 slot (3×3 grid) -->
+      <section class="px-4 py-3">
+        <div class="d-flex align-center ga-3 mb-2">
+          <h2 class="text-subtitle-1 font-weight-bold ma-0">
+            <v-icon :icon="mdiKeyboardOutline" size="small" class="me-1"></v-icon>
+            {{ $t('soundboard.pinned_section') }}
+          </h2>
+          <span class="text-caption text-medium-emphasis">{{ $t('soundboard.pinned_hint') }}</span>
+          <v-spacer></v-spacer>
+          <v-btn
+            v-if="soundboard.pinnedCount > 0"
+            :prepend-icon="mdiBackspaceOutline"
+            variant="text"
+            size="small"
+            class="text-none text-medium-emphasis"
+            @click="soundboard.clearAllSlots"
+          >
+            {{ $t('soundboard.clear_all') }}
+          </v-btn>
+        </div>
+
+        <!-- ClientOnly:slot 內容依賴 cookie 持久化的 store,SSR/prerender 時讀不到 cookie
+             會跟 client 真值不一致 → Vue 警告 hydration mismatch 且 class 不會更新。
+             所以 slot 區塊只在 client render,fallback 期間給 9 個純 empty slot 撐住版面。 -->
+        <ClientOnly>
+          <div class="soundboard-slots">
+            <div
+              v-for="(slotId, idx) in soundboard.pinnedSlots"
+              :key="idx"
+              class="soundboard-slot"
+              :class="{ 'soundboard-slot-empty': !slotId, 'soundboard-slot-drag-over': dragOverSlot === idx }"
+              @dragover.prevent="dragOverSlot = idx"
+              @dragleave="dragOverSlot = -1"
+              @drop.prevent="onDropOnSlot(idx, $event)"
+              @click="onSlotClick(idx)"
+            >
+              <span class="soundboard-slot-key">{{ idx + 1 }}</span>
+              <span class="soundboard-slot-label">
+                {{ slotId ? voiceLabel(slotId) : $t('soundboard.empty_slot') }}
+              </span>
+              <v-btn
+                v-if="slotId"
+                :icon="mdiCloseCircle"
+                :aria-label="$t('soundboard.clear_slot')"
+                variant="text"
+                density="comfortable"
+                size="x-small"
+                class="soundboard-slot-clear"
+                @click.stop="soundboard.clearSlot(idx)"
+              ></v-btn>
+            </div>
+          </div>
+          <template #fallback>
+            <div class="soundboard-slots">
+              <div v-for="n in 9" :key="n" class="soundboard-slot soundboard-slot-empty">
+                <span class="soundboard-slot-key">{{ n }}</span>
+                <span class="soundboard-slot-label">…</span>
+              </div>
+            </div>
+          </template>
+        </ClientOnly>
+      </section>
+
+      <v-divider></v-divider>
+
+      <!-- 搜尋 + voice grid -->
+      <section class="px-4 py-3 flex-grow-1">
+        <v-text-field
+          v-model="searchInput"
+          :placeholder="$t('soundboard.search_placeholder')"
+          :prepend-inner-icon="mdiMagnify"
+          :clearable="true"
+          variant="outlined"
+          density="comfortable"
+          hide-details
+          class="mb-3"
+          @update:model-value="v => (searchInput = v ?? '')"
+        ></v-text-field>
+
+        <div class="d-flex align-center ga-2 mb-2 text-caption text-medium-emphasis">
+          <v-icon :icon="mdiMusicBoxMultipleOutline" size="small"></v-icon>
+          <span>{{ $t('soundboard.voice_list_section') }} ({{ filteredVoices.length }})</span>
+        </div>
+
+        <div class="soundboard-voice-grid">
+          <button
+            v-for="item in filteredVoices"
+            :key="item.id"
+            type="button"
+            class="soundboard-voice-btn"
+            draggable="true"
+            :aria-label="item.description[currentLocale] || item.name"
+            @dragstart="onDragStart(item.id, $event)"
+            @click="previewItem(item)"
+          >
+            {{ item.description[currentLocale] || item.description.zh || item.name }}
+          </button>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue';
+import {
+  mdiVolumeHigh,
+  mdiHome,
+  mdiLayersTriple,
+  mdiMagnify,
+  mdiKeyboardOutline,
+  mdiCloseCircle,
+  mdiBackspaceOutline,
+  mdiMonitor,
+  mdiMusicBoxMultipleOutline
+} from '@mdi/js';
+import { useSoundboardStore } from '~/stores/soundboard';
+
+// 用獨立 minimal layout (沒 drawer / app-bar / footer)
+// ssr: false — 純互動,鍵盤事件 / 拖曳全 client
+definePageMeta({
+  layout: 'soundboard',
+  ssr: false
+});
+
+const { data: voice_lists } = await useAsyncData('voices', () => $fetch('/api/voices'), {
+  default: () => ({ groups: [] })
+});
+
+const { t, locale } = useI18n();
+const localePath = useLocalePath();
+const audioStore = useAudioStore();
+const soundboard = useSoundboardStore();
+
+const currentLocale = computed(() => locale.value);
+
+const searchInput = ref('');
+const dragOverSlot = ref(-1);
+const isMobile = ref(false);
+
+// flatten 所有 voice 並準備 ID → voice 查表
+const allVoices = computed(() => {
+  const arr = [];
+  for (const g of voice_lists.value.groups) {
+    for (const v of g.voice_list) arr.push(v);
+  }
+  return arr;
+});
+
+const voiceById = computed(() => {
+  const m = {};
+  for (const v of allVoices.value) m[v.id] = v;
+  return m;
+});
+
+const voiceLabel = id => {
+  const v = voiceById.value[id];
+  if (!v) return '';
+  return v.description?.[currentLocale.value] || v.description?.zh || v.name;
+};
+
+// 搜尋 filter (簡單,用名稱/描述包含關鍵字)
+const filteredVoices = computed(() => {
+  const q = searchInput.value.trim().toLowerCase();
+  if (!q) return allVoices.value;
+  return allVoices.value.filter(v => {
+    if (v.name?.toLowerCase().includes(q)) return true;
+    if (v.description) {
+      for (const key of Object.keys(v.description)) {
+        if (v.description[key]?.toString().toLowerCase().includes(q)) return true;
+      }
+    }
+    return false;
+  });
+});
+
+// 偵測行動裝置 (rough by viewport width)
+const updateMobile = () => {
+  isMobile.value = typeof window !== 'undefined' && window.innerWidth < 1024;
+};
+
+// ===== Drag & Drop =====
+const onDragStart = (voiceId, e) => {
+  e.dataTransfer.setData('text/x-voice-id', voiceId);
+  e.dataTransfer.effectAllowed = 'copy';
+};
+
+const onDropOnSlot = (slotIdx, e) => {
+  const voiceId = e.dataTransfer.getData('text/x-voice-id');
+  dragOverSlot.value = -1;
+  if (voiceId) soundboard.setSlot(slotIdx, voiceId);
+};
+
+// 點空 slot 不做事 (預留給未來 click-to-assign,目前 v1 只用拖曳)
+const onSlotClick = idx => {
+  const id = soundboard.pinnedSlots[idx];
+  if (id) playPinned(idx);
+};
+
+// ===== Play =====
+const previewItem = item => {
+  audioStore.play(item, item.description?.[currentLocale.value] || item.name, t('control.full_name'), t('site.title'));
+};
+
+const playPinned = slotIdx => {
+  const voiceId = soundboard.pinnedSlots[slotIdx];
+  if (!voiceId) return;
+  const item = voiceById.value[voiceId];
+  if (item) previewItem(item);
+};
+
+// ===== Keyboard 1-9 =====
+const onKeyDown = e => {
+  // input focus 中不觸發 (使用者在打字)
+  const tag = (e.target instanceof HTMLElement && e.target.tagName) || '';
+  if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+  if (e.ctrlKey || e.metaKey || e.altKey) return;
+  const key = e.key;
+  if (key >= '1' && key <= '9') {
+    const idx = parseInt(key, 10) - 1;
+    if (soundboard.pinnedSlots[idx]) {
+      playPinned(idx);
+      e.preventDefault();
+    }
+  }
+};
+
+// ===== Overlap lifecycle =====
+// 進頁時把 audioStore.overlap 設成 soundboard.overlap;
+// 離開時還原 audioStore.overlap = false (避免污染其他頁面)
+const onToggleOverlap = () => {
+  soundboard.toggleOverlap();
+  audioStore.overlap = soundboard.overlap;
+};
+
+watch(
+  () => soundboard.overlap,
+  v => {
+    audioStore.overlap = v;
+  }
+);
+
+// 載入後處理:reset 殘留播放狀態 + prune stale slots
+onMounted(() => {
+  updateMobile();
+  window.addEventListener('resize', updateMobile);
+  window.addEventListener('keydown', onKeyDown);
+  // 啟用 overlap (從 store 讀)
+  audioStore.overlap = soundboard.overlap;
+});
+
+watch(
+  () => voice_lists.value?.groups?.length,
+  len => {
+    if (!len) return;
+    const validIds = new Set();
+    voice_lists.value.groups.forEach(g => g.voice_list.forEach(v => validIds.add(v.id)));
+    soundboard.pruneStaleSlots(validIds);
+  },
+  { immediate: true }
+);
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', updateMobile);
+  window.removeEventListener('keydown', onKeyDown);
+  // 還原 overlap = false 避免污染其他頁面
+  audioStore.overlap = false;
+  audioStore.stopAll();
+});
+
+useSeoMeta({
+  title: () => t('soundboard.title'),
+  description: () => t('soundboard.subtitle'),
+  robots: 'noindex, nofollow'
+});
+</script>
+
+<style scoped>
+.soundboard-root {
+  background-color: #1a181d;
+  min-height: 100vh;
+}
+
+.soundboard-topbar {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+/* 9 格 3x3 grid */
+.soundboard-slots {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+@media (min-width: 1280px) {
+  .soundboard-slots {
+    grid-template-columns: repeat(9, 1fr);
+  }
+}
+
+.soundboard-slot {
+  position: relative;
+  display: flex;
+  align-items: center;
+  ga: 8px;
+  padding: 8px 10px;
+  min-height: 56px;
+  background-color: #2a2730;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  cursor: pointer;
+  transition:
+    background-color 0.15s,
+    border-color 0.15s;
+}
+.soundboard-slot:hover {
+  background-color: #353140;
+  border-color: rgba(255, 255, 255, 0.15);
+}
+.soundboard-slot-empty {
+  background-color: transparent;
+  border-style: dashed;
+  cursor: default;
+  opacity: 0.7;
+}
+.soundboard-slot-drag-over {
+  border-color: rgb(var(--v-theme-primary)) !important;
+  background-color: rgba(189, 19, 61, 0.15);
+}
+
+.soundboard-slot-key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background-color: rgba(255, 255, 255, 0.1);
+  font-size: 0.75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  margin-right: 8px;
+}
+.soundboard-slot-empty .soundboard-slot-key {
+  background-color: rgba(255, 255, 255, 0.05);
+  opacity: 0.6;
+}
+
+.soundboard-slot-label {
+  flex-grow: 1;
+  font-size: 0.875rem;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: rgba(255, 255, 255, 0.9);
+}
+.soundboard-slot-empty .soundboard-slot-label {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.4);
+  font-style: italic;
+}
+
+.soundboard-slot-clear {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.soundboard-slot:hover .soundboard-slot-clear {
+  opacity: 0.7;
+}
+.soundboard-slot-clear:hover {
+  opacity: 1;
+}
+
+/* Voice grid:緊湊小按鈕,1 row 多顆 */
+.soundboard-voice-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.soundboard-voice-btn {
+  padding: 6px 12px;
+  background-color: #2a2730;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.875rem;
+  cursor: grab;
+  transition:
+    background-color 0.12s,
+    border-color 0.12s;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.soundboard-voice-btn:hover {
+  background-color: #3a3640;
+  border-color: rgba(255, 255, 255, 0.2);
+}
+.soundboard-voice-btn:active {
+  cursor: grabbing;
+  background-color: rgb(var(--v-theme-primary));
+  border-color: rgb(var(--v-theme-primary));
+  color: white;
+}
+</style>

--- a/app/stores/soundboard.ts
+++ b/app/stores/soundboard.ts
@@ -1,0 +1,54 @@
+import { defineStore } from 'pinia';
+
+// 灰妲 Soundboard store — 給實況主用的快速播放工具狀態
+//
+// 設計:
+// 1. pinnedSlots:9 個快捷鍵 slot,每格存一個 voiceId 或 null
+//    使用者可以拖曳 voice 到任一格,設定鍵盤 1-9 的播放快捷鍵
+// 2. overlap:soundboard 的疊播設定,跟 audioStore.overlap 不同步存,
+//    進頁時把這個值套到 audioStore.overlap,離開時 audioStore.overlap 還原 false
+//    這樣 streamer 的 soundboard 設定不會洩漏到其他頁面 (例如首頁)
+// 3. persist:整個 state 都存 cookie,streamer 下次回來不用重新設定
+
+export const SLOT_COUNT = 9;
+
+export const useSoundboardStore = defineStore('soundboard', {
+  state: () => ({
+    pinnedSlots: Array<string | null>(SLOT_COUNT).fill(null) as (string | null)[],
+    overlap: true // 預設 on (streamer 常用法是連點同一條疊播)
+  }),
+
+  getters: {
+    // 第 N 格 (1-based) 是否有 pinned voice
+    isSlotFilled: state => (slotIdx: number) => state.pinnedSlots[slotIdx] != null,
+    pinnedCount: state => state.pinnedSlots.filter(v => v != null).length
+  },
+
+  actions: {
+    // 把 voice pin 到指定 slot (0-based index)
+    setSlot(slotIdx: number, voiceId: string) {
+      if (slotIdx < 0 || slotIdx >= SLOT_COUNT) return;
+      this.pinnedSlots[slotIdx] = voiceId;
+    },
+
+    clearSlot(slotIdx: number) {
+      if (slotIdx < 0 || slotIdx >= SLOT_COUNT) return;
+      this.pinnedSlots[slotIdx] = null;
+    },
+
+    clearAllSlots() {
+      this.pinnedSlots = Array(SLOT_COUNT).fill(null);
+    },
+
+    toggleOverlap() {
+      this.overlap = !this.overlap;
+    },
+
+    // 載入後清掉 stale voiceId (voices.json 已不存在的)
+    pruneStaleSlots(validVoiceIds: Set<string>) {
+      this.pinnedSlots = this.pinnedSlots.map(v => (v && validVoiceIds.has(v) ? v : null));
+    }
+  },
+
+  persist: true
+});

--- a/i18n/locales/default.json
+++ b/i18n/locales/default.json
@@ -106,6 +106,24 @@
     "added_count": "已加入 {count} 次",
     "drag_tip": "拖曳左側握把可調整播放順序"
   },
+  "soundboard": {
+    "title": "灰妲 Soundboard",
+    "subtitle": "給實況主的快速播放工具,按鍵盤 1~9 即時播放",
+    "back_to_home": "回主站",
+    "overlap": "疊播",
+    "overlap_hint": "連點同一條會疊播 (適合連發迷因)",
+    "pinned_section": "鍵盤快捷鍵",
+    "pinned_hint": "拖曳下方的語音到格子設定 1~9 快捷鍵",
+    "empty_slot": "拖曳語音到此",
+    "clear_slot": "清空此格",
+    "clear_all": "全部清空",
+    "search_placeholder": "搜尋語音(中/日/英)...",
+    "no_pinned": "還沒設定任何快捷鍵 — 拖曳下方語音到格子,或直接點擊播放",
+    "voice_list_section": "全部語音",
+    "mobile_hint_title": "建議使用桌面瀏覽器",
+    "mobile_hint_body": "Soundboard 設計給實況主用鍵盤快捷鍵操作,行動裝置不支援拖曳和 1~9 鍵。回主站使用一般版本。",
+    "streamer_tool": "實況工具"
+  },
   "search": {
     "placeholder": "搜尋語音(中/日/英)",
     "clear": "清除",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -106,6 +106,24 @@
     "added_count": "Added {count} times",
     "drag_tip": "Drag the handle on the left to reorder"
   },
+  "soundboard": {
+    "title": "DaDa Soundboard",
+    "subtitle": "A quick-play tool for streamers — press 1~9 to fire pinned voices",
+    "back_to_home": "Back to home",
+    "overlap": "Overlap",
+    "overlap_hint": "Repeated clicks layer the same voice on top of each other",
+    "pinned_section": "Keyboard shortcuts",
+    "pinned_hint": "Drag voices from below into the slots to assign keys 1~9",
+    "empty_slot": "Drop a voice here",
+    "clear_slot": "Clear this slot",
+    "clear_all": "Clear all",
+    "search_placeholder": "Search voices (zh/ja/en)...",
+    "no_pinned": "No shortcuts yet — drag voices from below, or click any voice to play it",
+    "voice_list_section": "All voices",
+    "mobile_hint_title": "Desktop browser recommended",
+    "mobile_hint_body": "The soundboard is designed for streamers using keyboard shortcuts. Drag-and-drop and 1~9 keys don't work on mobile. Go back to home for the standard experience.",
+    "streamer_tool": "Streamer tools"
+  },
   "search": {
     "placeholder": "Search voices (zh/ja/en)",
     "clear": "Clear",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -106,6 +106,24 @@
     "added_count": "{count} 回追加済み",
     "drag_tip": "左のハンドルをドラッグして並び替え"
   },
+  "soundboard": {
+    "title": "灰妲 Soundboard",
+    "subtitle": "配信者向けクイック再生ツール、1〜9 キーで即時再生",
+    "back_to_home": "ホームへ戻る",
+    "overlap": "重ね再生",
+    "overlap_hint": "同じ音声を連打すると重なって再生されます",
+    "pinned_section": "キーボードショートカット",
+    "pinned_hint": "下の音声をドラッグして 1〜9 のショートカットに設定",
+    "empty_slot": "音声をここにドラッグ",
+    "clear_slot": "このスロットをクリア",
+    "clear_all": "全てクリア",
+    "search_placeholder": "音声を検索(中/日/英)...",
+    "no_pinned": "ショートカット未設定 — 下の音声をドラッグするか、直接クリックで再生",
+    "voice_list_section": "すべての音声",
+    "mobile_hint_title": "デスクトップブラウザ推奨",
+    "mobile_hint_body": "Soundboard は配信者がキーボードで操作することを想定しており、モバイルではドラッグや 1〜9 キーが使えません。ホームへ戻って通常版をご利用ください。",
+    "streamer_tool": "配信ツール"
+  },
   "search": {
     "placeholder": "音声を検索(中/日/英)",
     "clear": "クリア",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -23,9 +23,9 @@ export default defineNuxtConfig({
     prerender: {
       crawlLinks: true,
       routes: [
-        '/', '/favorite', '/compose', '/challenge', '/feedback', '/privacy',
-        '/ja', '/ja/favorite', '/ja/compose', '/ja/challenge', '/ja/feedback', '/ja/privacy',
-        '/en', '/en/favorite', '/en/compose', '/en/challenge', '/en/feedback', '/en/privacy'
+        '/', '/favorite', '/compose', '/soundboard', '/challenge', '/feedback', '/privacy',
+        '/ja', '/ja/favorite', '/ja/compose', '/ja/soundboard', '/ja/challenge', '/ja/feedback', '/ja/privacy',
+        '/en', '/en/favorite', '/en/compose', '/en/soundboard', '/en/challenge', '/en/feedback', '/en/privacy'
       ],
       ignore: ['/member', '/ja/member', '/en/member']
     }
@@ -90,7 +90,8 @@ export default defineNuxtConfig({
 
   // 自動產生 sitemap.xml,含 i18n hreflang
   sitemap: {
-    exclude: ['/member', '/feedback', '/*/member', '/*/feedback']
+    // soundboard 是給實況主的工具,robots noindex,sitemap 也不列
+    exclude: ['/member', '/feedback', '/soundboard', '/*/member', '/*/feedback', '/*/soundboard']
   },
 
   gtag: {

--- a/tests/e2e/soundboard.spec.ts
+++ b/tests/e2e/soundboard.spec.ts
@@ -1,0 +1,251 @@
+import { test, expect } from '@playwright/test';
+
+// Soundboard (PR16) — 給實況主的快速播放工具
+//
+// 注意:HTML5 drag-and-drop 在 Playwright 上很難可靠模擬 (尤其用 native drag events),
+// 改用直接寫 cookie / 點擊 / 鍵盤事件來驗 store 跟 UI 行為。
+// 拖曳本身的 store action (setSlot) 由 unit test 覆蓋。
+
+test.describe('Soundboard page', () => {
+  test('desktop: initial state shows 9 empty slots + voice grid + toggle', async ({ page, context }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await context.clearCookies();
+    await page.goto('/soundboard');
+    await page.waitForLoadState('networkidle');
+
+    // 9 個 slots
+    await expect(page.locator('.soundboard-slot')).toHaveCount(9);
+    // 都是空的 (有 empty class)
+    await expect(page.locator('.soundboard-slot-empty')).toHaveCount(9);
+    // Overlap toggle visible (預設 ON)
+    const overlapBtn = page.getByRole('button', { name: /疊播/ });
+    await expect(overlapBtn).toBeVisible();
+    await expect(overlapBtn).toHaveAttribute('aria-pressed', 'true');
+    // 回主站連結
+    await expect(page.getByRole('link', { name: /回主站/ })).toBeVisible();
+    // Voice grid 有 buttons (至少很多)
+    const voiceBtns = page.locator('.soundboard-voice-btn');
+    expect(await voiceBtns.count()).toBeGreaterThan(50);
+  });
+
+  test('mobile: shows hint instead of soundboard UI', async ({ page, context }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await context.clearCookies();
+    await page.goto('/soundboard');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('建議使用桌面瀏覽器')).toBeVisible();
+    // Soundboard 主介面不應該出現
+    await expect(page.locator('.soundboard-slots')).toHaveCount(0);
+    // 回主站按鈕在
+    await expect(page.getByRole('link', { name: /回主站/ })).toBeVisible();
+  });
+
+  test('toggle overlap: aria-pressed flips', async ({ page, context }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await context.clearCookies();
+    await page.goto('/soundboard');
+    await page.waitForLoadState('networkidle');
+
+    const overlapBtn = page.getByRole('button', { name: /疊播/ });
+    await expect(overlapBtn).toHaveAttribute('aria-pressed', 'true');
+    await overlapBtn.click();
+    await expect(overlapBtn).toHaveAttribute('aria-pressed', 'false');
+    await overlapBtn.click();
+    await expect(overlapBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('search filters voice grid', async ({ page, context }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await context.clearCookies();
+    await page.goto('/soundboard');
+    await page.waitForLoadState('networkidle');
+
+    const initialCount = await page.locator('.soundboard-voice-btn').count();
+    expect(initialCount).toBeGreaterThan(50);
+
+    // 搜尋一個很短的字串應該縮減結果
+    await page.getByPlaceholder(/搜尋語音/).fill('天');
+    await page.waitForTimeout(300);
+    const filteredCount = await page.locator('.soundboard-voice-btn').count();
+    expect(filteredCount).toBeLessThan(initialCount);
+    expect(filteredCount).toBeGreaterThan(0);
+  });
+
+  test('pinned slot displays voice name + clicking it plays', async ({ page, context }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await context.clearCookies();
+    await page.addInitScript(() => {
+      (window as any).__playCalls = [];
+      HTMLAudioElement.prototype.play = function () {
+        (window as any).__playCalls.push(this.src);
+        return Promise.resolve();
+      };
+      HTMLAudioElement.prototype.load = function () {
+        setTimeout(() => this.dispatchEvent(new Event('canplay')), 0);
+      };
+    });
+
+    // 先到主站拿 voice id
+    await page.goto('/');
+    const voiceIds = await page.evaluate(async () => {
+      const data = await (await fetch('/voices.json')).json();
+      return data.groups[0].voice_list.slice(0, 2).map((v: any) => v.id);
+    });
+
+    // 寫 soundboard cookie
+    await context.addCookies([
+      {
+        name: 'soundboard',
+        value: encodeURIComponent(
+          JSON.stringify({
+            pinnedSlots: [voiceIds[0], voiceIds[1], null, null, null, null, null, null, null],
+            overlap: true
+          })
+        ),
+        url: 'http://localhost:4174'
+      }
+    ]);
+
+    await page.goto('/soundboard');
+    await page.waitForLoadState('networkidle');
+
+    // 前兩個 slot 應該不再是 empty (沒有 -empty class)
+    await expect(page.locator('.soundboard-slot').nth(0)).not.toHaveClass(/soundboard-slot-empty/);
+    await expect(page.locator('.soundboard-slot').nth(1)).not.toHaveClass(/soundboard-slot-empty/);
+    await expect(page.locator('.soundboard-slot').nth(2)).toHaveClass(/soundboard-slot-empty/);
+
+    // 點第一個 slot 應該觸發 audio.play()
+    await page.locator('.soundboard-slot').nth(0).click();
+    await expect
+      .poll(async () => (await page.evaluate(() => (window as any).__playCalls?.length || 0)) > 0, {
+        timeout: 3000
+      })
+      .toBe(true);
+  });
+
+  test('keyboard 1-9: triggers pinned slot play', async ({ page, context }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await context.clearCookies();
+    await page.addInitScript(() => {
+      (window as any).__playCalls = [];
+      HTMLAudioElement.prototype.play = function () {
+        (window as any).__playCalls.push(this.src);
+        return Promise.resolve();
+      };
+      HTMLAudioElement.prototype.load = function () {
+        setTimeout(() => this.dispatchEvent(new Event('canplay')), 0);
+      };
+    });
+
+    await page.goto('/');
+    const voiceIds = await page.evaluate(async () => {
+      const data = await (await fetch('/voices.json')).json();
+      return data.groups[0].voice_list.slice(0, 1).map((v: any) => v.id);
+    });
+    await context.addCookies([
+      {
+        name: 'soundboard',
+        value: encodeURIComponent(
+          JSON.stringify({
+            pinnedSlots: [voiceIds[0], null, null, null, null, null, null, null, null],
+            overlap: true
+          })
+        ),
+        url: 'http://localhost:4174'
+      }
+    ]);
+
+    await page.goto('/soundboard');
+    await page.waitForLoadState('networkidle');
+
+    // 按 1 鍵 (頁面 body 有 focus)
+    await page.locator('body').click();
+    await page.keyboard.press('1');
+    await expect
+      .poll(async () => (await page.evaluate(() => (window as any).__playCalls?.length || 0)) > 0, {
+        timeout: 3000
+      })
+      .toBe(true);
+  });
+
+  test('keyboard 1-9: NOT triggered when typing in search input', async ({ page, context }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await context.clearCookies();
+    await page.addInitScript(() => {
+      (window as any).__playCalls = [];
+      HTMLAudioElement.prototype.play = function () {
+        (window as any).__playCalls.push(this.src);
+        return Promise.resolve();
+      };
+    });
+
+    await page.goto('/');
+    const voiceIds = await page.evaluate(async () => {
+      const data = await (await fetch('/voices.json')).json();
+      return data.groups[0].voice_list.slice(0, 1).map((v: any) => v.id);
+    });
+    await context.addCookies([
+      {
+        name: 'soundboard',
+        value: encodeURIComponent(
+          JSON.stringify({
+            pinnedSlots: [voiceIds[0], null, null, null, null, null, null, null, null],
+            overlap: true
+          })
+        ),
+        url: 'http://localhost:4174'
+      }
+    ]);
+    await page.goto('/soundboard');
+    await page.waitForLoadState('networkidle');
+
+    // Focus 搜尋輸入框
+    await page.getByPlaceholder(/搜尋語音/).focus();
+    await page.keyboard.press('1');
+    // play() 不應該被觸發 (按鍵被當打字)
+    await page.waitForTimeout(200);
+    const calls = await page.evaluate(() => (window as any).__playCalls?.length || 0);
+    expect(calls).toBe(0);
+  });
+
+  test('clear all button removes all pinned slots', async ({ page, context }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await context.clearCookies();
+
+    await page.goto('/');
+    const voiceIds = await page.evaluate(async () => {
+      const data = await (await fetch('/voices.json')).json();
+      return data.groups[0].voice_list.slice(0, 2).map((v: any) => v.id);
+    });
+    await context.addCookies([
+      {
+        name: 'soundboard',
+        value: encodeURIComponent(
+          JSON.stringify({
+            pinnedSlots: [voiceIds[0], voiceIds[1], null, null, null, null, null, null, null],
+            overlap: true
+          })
+        ),
+        url: 'http://localhost:4174'
+      }
+    ]);
+    await page.goto('/soundboard');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('.soundboard-slot-empty')).toHaveCount(7);
+    await page.getByRole('button', { name: /全部清空/ }).click();
+    await expect(page.locator('.soundboard-slot-empty')).toHaveCount(9);
+  });
+});
+
+test.describe('Soundboard footer link from home', () => {
+  test('footer has 實況工具 link to /soundboard', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    const footerLink = page.getByRole('link', { name: '實況工具' });
+    await expect(footerLink).toBeVisible();
+    await footerLink.click();
+    await expect(page).toHaveURL(/\/soundboard\/?$/);
+  });
+});

--- a/tests/unit/soundboardStore.test.ts
+++ b/tests/unit/soundboardStore.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useSoundboardStore, SLOT_COUNT } from '../../app/stores/soundboard';
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+describe('soundboard store', () => {
+  describe('initial state', () => {
+    it('has 9 empty slots', () => {
+      const s = useSoundboardStore();
+      expect(s.pinnedSlots).toHaveLength(SLOT_COUNT);
+      expect(s.pinnedSlots.every(v => v === null)).toBe(true);
+      expect(s.pinnedCount).toBe(0);
+    });
+
+    it('overlap defaults to true (streamer-friendly)', () => {
+      const s = useSoundboardStore();
+      expect(s.overlap).toBe(true);
+    });
+  });
+
+  describe('setSlot', () => {
+    it('assigns voiceId to specified slot', () => {
+      const s = useSoundboardStore();
+      s.setSlot(0, 'v1');
+      expect(s.pinnedSlots[0]).toBe('v1');
+      expect(s.pinnedCount).toBe(1);
+      expect(s.isSlotFilled(0)).toBe(true);
+      expect(s.isSlotFilled(1)).toBe(false);
+    });
+
+    it('overwrites existing slot', () => {
+      const s = useSoundboardStore();
+      s.setSlot(2, 'old');
+      s.setSlot(2, 'new');
+      expect(s.pinnedSlots[2]).toBe('new');
+      expect(s.pinnedCount).toBe(1);
+    });
+
+    it('ignores out-of-range index', () => {
+      const s = useSoundboardStore();
+      s.setSlot(-1, 'v1');
+      s.setSlot(99, 'v2');
+      expect(s.pinnedCount).toBe(0);
+    });
+
+    it('allows same voiceId in multiple slots', () => {
+      const s = useSoundboardStore();
+      s.setSlot(0, 'samevoice');
+      s.setSlot(3, 'samevoice');
+      expect(s.pinnedSlots[0]).toBe('samevoice');
+      expect(s.pinnedSlots[3]).toBe('samevoice');
+      expect(s.pinnedCount).toBe(2);
+    });
+  });
+
+  describe('clearSlot', () => {
+    it('removes voiceId from slot', () => {
+      const s = useSoundboardStore();
+      s.setSlot(4, 'v1');
+      s.clearSlot(4);
+      expect(s.pinnedSlots[4]).toBeNull();
+      expect(s.pinnedCount).toBe(0);
+    });
+
+    it('ignores out-of-range', () => {
+      const s = useSoundboardStore();
+      s.setSlot(0, 'v1');
+      s.clearSlot(-1);
+      s.clearSlot(99);
+      expect(s.pinnedSlots[0]).toBe('v1');
+    });
+  });
+
+  describe('clearAllSlots', () => {
+    it('resets all to null', () => {
+      const s = useSoundboardStore();
+      s.setSlot(0, 'a');
+      s.setSlot(5, 'b');
+      s.setSlot(8, 'c');
+      s.clearAllSlots();
+      expect(s.pinnedSlots.every(v => v === null)).toBe(true);
+      expect(s.pinnedCount).toBe(0);
+    });
+
+    it('keeps slot count at 9 after clear', () => {
+      const s = useSoundboardStore();
+      s.setSlot(0, 'a');
+      s.clearAllSlots();
+      expect(s.pinnedSlots).toHaveLength(SLOT_COUNT);
+    });
+  });
+
+  describe('toggleOverlap', () => {
+    it('toggles the overlap flag', () => {
+      const s = useSoundboardStore();
+      expect(s.overlap).toBe(true);
+      s.toggleOverlap();
+      expect(s.overlap).toBe(false);
+      s.toggleOverlap();
+      expect(s.overlap).toBe(true);
+    });
+  });
+
+  describe('pruneStaleSlots', () => {
+    it('clears slots whose voiceId is not in valid set', () => {
+      const s = useSoundboardStore();
+      s.setSlot(0, 'alive');
+      s.setSlot(2, 'dead');
+      s.setSlot(5, 'alive');
+      s.pruneStaleSlots(new Set(['alive']));
+      expect(s.pinnedSlots[0]).toBe('alive');
+      expect(s.pinnedSlots[2]).toBeNull();
+      expect(s.pinnedSlots[5]).toBe('alive');
+      expect(s.pinnedCount).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
新頁面 `/soundboard`,給實況主用的快速播放工具。

## Features

- ✅ **9 個鍵盤快捷鍵 slot** (1~9 numbers)
- ✅ **拖曳語音到 slot** 設定快捷鍵 (HTML5 draggable + drop)
- ✅ **鍵盤 1~9 即時播放** (input focus 時自動忽略,不會打字誤觸)
- ✅ **搜尋過濾** 全部 937 條語音
- ✅ **Overlap toggle** (預設 on,連發迷因常用)
- ✅ **Minimal layout** (沒 drawer / banner / footer,專注操作)
- ✅ **行動裝置 hint** 提示用桌面
- ✅ **三語系** i18n (zh/ja/en)
- ✅ **Cookie 持久化** (streamer 下次回來不用重新 pin)

## Architecture

- **`app/stores/soundboard.ts`** (新): pinnedSlots[9] + overlap + 6 actions (setSlot / clearSlot / clearAllSlots / toggleOverlap / pruneStaleSlots)
- **`app/pages/soundboard.vue`** (新): top bar + 9 slots + search + voice grid
- **`app/layouts/soundboard.vue`** (新): minimal layout (v-app + slot,蓋掉 critical CSS 的 v-main padding)
- **Overlap lifecycle**: 進頁時 \`audioStore.overlap = soundboard.overlap\`;離開時 restore false 避免污染其他頁
- **Footer 入口**: default layout footer 加「實況工具」連結 (一般使用者用不到,不放 nav drawer 避免雜亂)

## 踩到的坑 (順手解掉)

**Hydration mismatch on prerendered page with cookie-persisted store**:
- /soundboard 雖然 \`ssr: false\`,SSG prerender 階段仍會產靜態 HTML
- slot 內容依賴 cookie 持久化的 store,SSR 時讀不到 cookie → 跟 client 真值不一致
- Vue 警告 \"Hydration completed but contains mismatches\" 且 class 不會更新
- 怪現象:同一個 slot 同時有 \`-empty\` class + 渲染出 voice 名稱
- **解法**: 把 slot 區塊用 \`<ClientOnly>\` 包,fallback 期間給 9 個 empty placeholder 撐版面

## SEO/SSG

- robots: noindex, nofollow (沒搜尋價值)
- sitemap exclude /soundboard
- 仍 prerender 一份 HTML (跟 /member /compose 同 pattern,讓直接 URL 進得來)

## Tests

- **Unit** (\`tests/unit/soundboardStore.test.ts\`): 12 個 — slots 初始 / setSlot guard / 同 voice 多 slot / clearSlot / clearAllSlots / toggleOverlap / pruneStaleSlots
- **E2E** (\`tests/e2e/soundboard.spec.ts\`): 9 個 — desktop initial / mobile hint / overlap toggle / search filter / pinned slot 點擊播放 / 鍵盤 1-9 播放 / 鍵盤在搜尋框 focus 時不觸發 / clear all / footer link nav

## 驗證
- [x] Unit: 56/56 通過 (44 既有 + 12 新)
- [x] E2E: 61/61 通過 (52 既有 + 9 新)
- [x] Lint clean
- [x] \`pnpm generate\` SSG 68 routes 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)