### PR TITLE
fix(member): PR17 - /api/dc_voices 404 on static hosting

### DIFF
--- a/app/pages/member.vue
+++ b/app/pages/member.vue
@@ -89,8 +89,12 @@ definePageMeta({
   ssr: false
 });
 
-// dc_voices.json (~400KB) 改走 /api/dc_voices server route,避免內聯進 client JS bundle
-const { data: voice_lists } = await useAsyncData('dc_voices', () => $fetch('/api/dc_voices'), {
+// dc_voices.json (~400KB) 直接從 public/ 靜態檔抓 (避免內聯進 client JS bundle)。
+// 重要:不能用 $fetch('/api/dc_voices') — 那是 nitro server route,只在 prerender
+// (SSR) 階段被內部命中。member 頁是 ssr:false + 不被 prerender (在 nitro.ignore),
+// 所以 client 端 runtime 真的會打 /api/dc_voices,SSG 靜態 hosting 沒這 endpoint → 404。
+// /dc_voices.json 是 public/ 下的 static file,SSG output 直接 copy 過去,runtime 抓得到。
+const { data: voice_lists } = await useAsyncData('dc_voices', () => $fetch('/dc_voices.json'), {
   default: () => ({ groups: [] })
 });
 

--- a/server/api/dc_voices.get.ts
+++ b/server/api/dc_voices.get.ts
@@ -1,5 +1,0 @@
-import voices from '~~/public/dc_voices.json';
-
-// 同 voices.get.ts:server route 用 import 直接讀檔
-// member 頁是 client-only (ssr:false),這個 endpoint 主要給 client 端 $fetch 使用
-export default defineEventHandler(() => voices);

--- a/tests/e2e/member.spec.ts
+++ b/tests/e2e/member.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+
+// 會員頁 (/member) regression — PR8 改 /api/dc_voices 是 server route,
+// 但 member 是 ssr:false + 不被 prerender,client runtime 真的會打那個 endpoint,
+// SSG 靜態 hosting 上 → 404,整頁拿不到 voices 資料。
+// PR17 把它改成 fetch 靜態 /dc_voices.json。
+// 這個 spec 監視 page 載入過程不能有 404 + 載入後資料存在 (voice_lists.groups.length > 0)。
+
+test.describe('Member page (ssr:false)', () => {
+  test('navigates from drawer + dc_voices loads without 404', async ({ page }) => {
+    // 監聽 failed network requests
+    const failedRequests: string[] = [];
+    page.on('response', async res => {
+      if (!res.ok() && res.status() >= 400) {
+        const url = res.url();
+        // 只關心我們自己的 endpoint,Discord OAuth API 失敗是預期的 (沒登入)
+        if (url.includes('/api/') || url.includes('/dc_voices')) {
+          failedRequests.push(`${res.status()} ${url}`);
+        }
+      }
+    });
+
+    // 從首頁開始 (member 直接 URL 在 ignore 不會有 stub HTML,
+    // 必須用 SPA 內部路由跳過去)
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // drawer 點「會員專區」
+    const memberLink = page.getByRole('link', { name: /會員專區/ });
+    await memberLink.click();
+    await expect(page).toHaveURL(/\/member\/?$/);
+    await page.waitForLoadState('networkidle');
+
+    // 給 useAsyncData 一點時間完成
+    await page.waitForTimeout(500);
+
+    // 不能有 dc_voices 相關的 404
+    const dcVoicesErrors = failedRequests.filter(r => r.includes('dc_voices'));
+    expect(dcVoicesErrors, `unexpected failed requests:\n${dcVoicesErrors.join('\n')}`).toEqual([]);
+
+    // 頁面標題 / 主要元件存在 (Discord 未登入,所以會顯示 error alert + 「連結 Discord 帳號」按鈕)
+    await expect(page.getByText(/會員專區/).first()).toBeVisible();
+  });
+
+  test('dc_voices.json static file is accessible at runtime', async ({ request }) => {
+    const res = await request.get('/dc_voices.json');
+    expect(res.status()).toBe(200);
+    const data = await res.json();
+    expect(data.groups).toBeDefined();
+    expect(data.groups.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Bug
會員專區 (/member) 進去後,client-side \`\$fetch('/api/dc_voices')\` 拿到 **404**,voice_lists 是空的,會員區的語音清單載不出來。

## Root cause
PR8 把 \`dc_voices.json\` (~400KB) 從 client JS bundle 抽出來改走 server route \`/api/dc_voices\`,目標是 \"prerender 階段 nitro 內部命中 handler → 結果寫進 _payload.json\"。

但:
- \`/member\` 是 \`ssr: false\` + 在 \`nitro.ignore\` (走 Discord OAuth 拿不到 SSR 數據,當時不想 prerender)
- 結果 prerender **不會跑這頁** → 沒有 dc_voices 的 payload 產出
- Client runtime 跑 \`\$fetch('/api/dc_voices')\` 真的會去打 \`/api/dc_voices\` endpoint
- SSG 靜態 hosting (Vercel static) 沒這個 runtime endpoint → **404**

對照 /index、/compose:
- 它們用 \`\$fetch('/api/voices')\`,index 是 SSR + prerendered,payload 已經把 'voices' bake 進去
- /compose 雖然 ssr:false,但 useAsyncData 用**同樣 key** 'voices' → client hydration 直接命中 payload cache,不會真打 endpoint
- /member 用獨立 key 'dc_voices',沒人 prerender 過 → 無 payload 兜底

## Fix
- \`member.vue\` 改用 \`\$fetch('/dc_voices.json')\` 直接抓 \`public/\` 下的靜態檔
  - SSG output 會 copy 到 \`.output/public/dc_voices.json\`,runtime hosting 直接 serve
- 移除沒用了的 \`server/api/dc_voices.get.ts\`

## Tests
新增 \`tests/e2e/member.spec.ts\` (2 tests):
1. 從 drawer 點進 /member,監聽 network response 不能有 dc_voices 相關 404
2. \`/dc_voices.json\` static file 真的 200 可訪問

## 驗證
- [x] 63/63 e2e 通過 (61 既有 + 2 新)
- [x] 56/56 unit
- [x] Lint clean
- [x] curl \`/dc_voices.json\` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)