### PR TITLE
feat(member): PR18 - Discord OAuth Authorization Code Grant + refresh token

### DIFF
--- a/app/pages/member.vue
+++ b/app/pages/member.vue
@@ -36,7 +36,7 @@
               </v-alert>
             </div>
 
-            <div class="d-flex gap-2 mt-6">
+            <div class="d-flex ga-2 mt-6">
               <v-btn v-if="!isAuthorized" color="success" size="large" class="px-8" @click="fetchAccountInfo">
                 {{ $t('member.refresh') }}
               </v-btn>
@@ -80,7 +80,6 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { mdiLink } from '@mdi/js';
-// 💡 引入 AudioStore 與 Snackbar
 import { useAudioStore } from '~/stores/audio';
 import { useSnackbar } from '~/composables/useSnackbar';
 
@@ -89,11 +88,7 @@ definePageMeta({
   ssr: false
 });
 
-// dc_voices.json (~400KB) 直接從 public/ 靜態檔抓 (避免內聯進 client JS bundle)。
-// 重要:不能用 $fetch('/api/dc_voices') — 那是 nitro server route,只在 prerender
-// (SSR) 階段被內部命中。member 頁是 ssr:false + 不被 prerender (在 nitro.ignore),
-// 所以 client 端 runtime 真的會打 /api/dc_voices,SSG 靜態 hosting 沒這 endpoint → 404。
-// /dc_voices.json 是 public/ 下的 static file,SSG output 直接 copy 過去,runtime 抓得到。
+// dc_voices.json 走 public/ 靜態檔 (PR17 修)
 const { data: voice_lists } = await useAsyncData('dc_voices', () => $fetch('/dc_voices.json'), {
   default: () => ({ groups: [] })
 });
@@ -103,12 +98,22 @@ const settings = useSettingsStore();
 const audioStore = useAudioStore();
 const snackbar = useSnackbar();
 const config = useRuntimeConfig();
-const discordCookie = useCookie('discord_token');
 const { gtag } = useGtag();
 
-// 狀態變數 (改 computed 跟著 voice_lists ref 變動)
+// === Discord OAuth state (cookies) ===
+// PR18: 從 Implicit Grant 換成 Authorization Code Grant + refresh token。
+// 三個 cookies 一起管:
+//   discord_access_token   — 7 天有效,呼叫 Discord API 用
+//   discord_refresh_token  — 長效,access 過期時用來換新的
+//   discord_token_expires_at — ms unix timestamp,client 端判斷是否該 refresh
+// 設 maxAge 30 天 (refresh 通常比 access 長壽,可以更長)
+const COOKIE_OPTS = { maxAge: 60 * 60 * 24 * 30 };
+const accessTokenCookie = useCookie('discord_access_token', COOKIE_OPTS);
+const refreshTokenCookie = useCookie('discord_refresh_token', COOKIE_OPTS);
+const expiresAtCookie = useCookie('discord_token_expires_at', COOKIE_OPTS);
+
+// 狀態變數
 const groups = computed(() => voice_lists.value.groups);
-// 💡 移除了 `now_playing` 與 `voiceBtnRefs` 等舊版手動管理的狀態
 const loading = ref(true);
 const error = ref(null);
 const account = ref(null);
@@ -117,58 +122,154 @@ const panel = ref([]);
 const abortController = ref(null);
 
 // 計算屬性
-const dark_text = computed(() => ({
-  'text-grey-lighten-2': settings.dark
-}));
-
+const dark_text = computed(() => ({ 'text-grey-lighten-2': settings.dark }));
 const current_locale = computed(() => locale.value);
+const isAuthorized = computed(() => member.value?.roles && member.value.roles.length > 0);
 
-const isAuthorized = computed(() => {
-  return member.value?.roles && member.value.roles.length > 0;
-});
+// === Token helpers ===
 
-// 生命週期：擷取網址 Hash 中的 Token
-onMounted(() => {
-  const hash = window.location.hash;
-  if (hash && hash.includes('access_token')) {
-    const params = new URLSearchParams(hash.substring(1));
-    const token = params.get('access_token');
-    if (token) {
-      discordCookie.value = token;
-      window.history.replaceState(null, '', window.location.pathname);
+// 把 server 回傳的 token bundle 存進 cookies
+const saveTokens = bundle => {
+  accessTokenCookie.value = bundle.access_token;
+  refreshTokenCookie.value = bundle.refresh_token;
+  expiresAtCookie.value = String(bundle.expires_at);
+};
+
+const clearTokens = () => {
+  accessTokenCookie.value = null;
+  refreshTokenCookie.value = null;
+  expiresAtCookie.value = null;
+};
+
+// Access token 是否快到期 (預留 1 分鐘 buffer)
+const isAccessTokenExpiring = () => {
+  if (!expiresAtCookie.value) return false;
+  const expiresAt = parseInt(expiresAtCookie.value, 10);
+  if (isNaN(expiresAt)) return true;
+  return Date.now() >= expiresAt - 60_000;
+};
+
+// 用 refresh_token 跟 server 換新的 access token,失敗回 false (代表需要重新授權)
+const tryRefresh = async () => {
+  if (!refreshTokenCookie.value) return false;
+  try {
+    const bundle = await $fetch('/api/discord/refresh', {
+      method: 'POST',
+      body: { refresh_token: refreshTokenCookie.value }
+    });
+    saveTokens(bundle);
+    return true;
+  } catch (err) {
+    console.warn('[member] refresh failed', err);
+    clearTokens();
+    return false;
+  }
+};
+
+// 取得有效的 access token:過期就先 refresh,還是失敗就回 null
+const getValidAccessToken = async () => {
+  if (!accessTokenCookie.value) return null;
+  if (isAccessTokenExpiring()) {
+    const ok = await tryRefresh();
+    if (!ok) return null;
+  }
+  return accessTokenCookie.value;
+};
+
+// === Lifecycle / Auth flow ===
+
+// 進頁時:處理 OAuth callback (URL 帶 ?code=...) 或直接用既有 token
+onMounted(async () => {
+  abortController.value = new AbortController();
+
+  const url = new URL(window.location.href);
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+  const oauthError = url.searchParams.get('error');
+
+  if (oauthError) {
+    // Discord 端拒絕授權 (例如使用者點 cancel)
+    cleanUrl();
+    error.value = 'member.error_authorization_required';
+    loading.value = false;
+    return;
+  }
+
+  if (code) {
+    // CSRF 防護:驗證 state 跟我們 redirect 前存的一致
+    const expectedState = sessionStorage.getItem('discord_oauth_state');
+    sessionStorage.removeItem('discord_oauth_state');
+    if (!expectedState || state !== expectedState) {
+      cleanUrl();
+      error.value = 'member.error_state_mismatch';
+      loading.value = false;
+      return;
+    }
+    // 把 code 送給 server 換 token
+    try {
+      const bundle = await $fetch('/api/discord/token', {
+        method: 'POST',
+        body: { code }
+      });
+      saveTokens(bundle);
+      cleanUrl();
+    } catch (err) {
+      console.error('[member] token exchange failed', err);
+      cleanUrl();
+      error.value = 'member.error_authorization_required';
+      loading.value = false;
+      return;
     }
   }
 
-  abortController.value = new AbortController();
-  fetchAccountInfo(abortController.value.signal);
+  await fetchAccountInfo(abortController.value.signal);
 });
 
 onUnmounted(() => {
   abortController.value?.abort();
 });
 
-// 方法
+// 清掉 URL 的 ?code=&state= (不要留在歷史紀錄)
+const cleanUrl = () => {
+  window.history.replaceState(null, '', window.location.pathname);
+};
+
+// === Fetch account / member info ===
+// 內建 reactive refresh:第一次 401 就試 refresh 後 retry 一次,還失敗就放棄
 const fetchAccountInfo = async signal => {
   loading.value = true;
   error.value = null;
   try {
-    const token = discordCookie.value;
+    const token = await getValidAccessToken();
     if (!token) throw new Error('');
 
-    const headers = { Authorization: `Bearer ${token}` };
     const apiBase = config.public.DISCORD_API_BASE || 'https://discord.com/api';
+    const guildId = '959421169629560892';
 
-    const accountRes = await fetch(`${apiBase}/users/@me`, { headers, signal });
+    // 包一個帶 retry 的 fetch:401 → refresh → 重打一次
+    const callDiscord = async (path, retried = false) => {
+      const accessToken = accessTokenCookie.value;
+      const res = await fetch(`${apiBase}${path}`, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        signal
+      });
+      if (res.status === 401 && !retried) {
+        // access token 在這幾毫秒間剛好失效 (or expires_at 算錯),試 refresh 再來一次
+        const ok = await tryRefresh();
+        if (ok) return callDiscord(path, true);
+      }
+      return res;
+    };
+
+    const accountRes = await callDiscord('/users/@me');
     if (accountRes.status === 401) throw new Error('member.error_authorization_required');
     else if (accountRes.status === 403) throw new Error('member.error_forbidden');
     else if (!accountRes.ok) throw new Error('member.error_get_member');
-
     account.value = await accountRes.json();
 
-    const memberRes = await fetch(`${apiBase}/users/@me/guilds/959421169629560892/member`, { headers, signal });
+    const memberRes = await callDiscord(`/users/@me/guilds/${guildId}/member`);
     if (memberRes.status === 404) throw new Error('member.error_not_found');
     else if (!memberRes.ok) throw new Error('member.error_get_member');
-
     member.value = await memberRes.json();
   } catch (err) {
     if (err.name === 'AbortError') return;
@@ -178,15 +279,41 @@ const fetchAccountInfo = async signal => {
   }
 };
 
+// === Redirect 到 Discord 授權 ===
 const redirectToDiscordAuth = () => {
   const clientId = config.public.DISCORD_CLIENT_ID;
   const redirectUri = config.public.DISCORD_REDIRECT_URI;
-  const discordAuthUrl = `https://discord.com/oauth2/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=token&prompt=none&scope=identify%20guilds%20guilds.members.read`;
-  window.location.href = discordAuthUrl;
+
+  // CSRF state:在 sessionStorage 存隨機字串,callback 時驗證
+  const state = crypto.randomUUID();
+  sessionStorage.setItem('discord_oauth_state', state);
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code', // ← PR18: implicit 'token' → code grant 'code'
+    scope: 'identify guilds guilds.members.read',
+    state
+  });
+
+  window.location.href = `https://discord.com/oauth2/authorize?${params.toString()}`;
 };
 
-const logout = () => {
-  discordCookie.value = null;
+// === Logout: revoke + clear ===
+const logout = async () => {
+  // 通知 Discord 把 token 作廢 (失敗也沒關係,本地 cookie 反正要清)
+  const accessToken = accessTokenCookie.value;
+  if (accessToken) {
+    try {
+      await $fetch('/api/discord/revoke', {
+        method: 'POST',
+        body: { token: accessToken, token_type_hint: 'access_token' }
+      });
+    } catch {
+      // ignore — revoke 失敗不擋 logout
+    }
+  }
+  clearTokens();
   account.value = null;
   member.value = null;
   error.value = 'member.error_logout';
@@ -216,12 +343,6 @@ const play = item => {
 
 useSeoMeta({
   title: () => t('member.member_area'),
-  robots: 'noindex, nofollow' // 會員專區需 Discord OAuth,不應被索引
+  robots: 'noindex, nofollow'
 });
 </script>
-
-<style scoped>
-.gap-2 {
-  gap: 8px;
-}
-</style>

--- a/i18n/locales/default.json
+++ b/i18n/locales/default.json
@@ -67,6 +67,7 @@
     "error_get_member": "獲取會員資訊失敗，請稍後再試。",
     "error_logout": "已登出，請重新連結Discord。",
     "error_not_found": "找不到會員身分組。",
+    "error_state_mismatch": "授權驗證失敗（state 不一致），請重新嘗試連結。",
     "link_discord": "連結 Discord 帳號",
     "loading": "載入中...",
     "member_area": "會員專區",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -67,6 +67,7 @@
     "error_get_member": "Failed to get member information, please try again later.",
     "error_logout": "Logged out. Please re-authenticate.",
     "error_not_found": "Member role not found.",
+    "error_state_mismatch": "Authorization verification failed (state mismatch). Please try linking again.",
     "link_discord": "Link Discord Account",
     "loading": "Loading...",
     "member_area": "Member Area",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -67,6 +67,7 @@
     "error_get_member": "メンバー情報の取得に失敗しました。後でもう一度お試しください。",
     "error_logout": "ログアウトしました。再認証してください。",
     "error_not_found": "メンバーロールが見つかりません。",
+    "error_state_mismatch": "認可の検証に失敗しました（state 不一致）。再度リンクしてください。",
     "link_discord": "Discordアカウントをリンク",
     "loading": "読み込み中...",
     "member_area": "メンバーエリア",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -19,7 +19,11 @@ export default defineNuxtConfig({
   // /compose 跟 /member 雖然 ssr:false,還是 prerender 一份 HTML stub,
   // 讓使用者直接打 URL 進來時 hosting (Vercel SSG) 能 serve 而不是 404。
   // stub 是空殼 + 全部 JS,進來後 client-side 自己 hydrate 整頁。
+  // preset=vercel:讓 nitro server routes (/api/discord/token, /api/discord/refresh)
+  // 變成 Vercel serverless functions,可以在 runtime 拿 DISCORD_CLIENT_SECRET 跟 Discord 換 token。
+  // prerendered pages 還是 prerender (純靜態 CDN),只有 /api/* 走 function。
   nitro: {
+    preset: 'vercel',
     prerender: {
       crawlLinks: true,
       routes: [
@@ -142,6 +146,9 @@ export default defineNuxtConfig({
   },
 
   runtimeConfig: {
+    // server-only (不出貨到 client bundle):Discord OAuth Authorization Code Grant
+    // 需要 client_secret 跟 Discord 換 token,只能放後端
+    DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
     public: {
       DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
       DISCORD_REDIRECT_URI: process.env.DISCORD_REDIRECT_URI,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig, devices } from '@playwright/test';
 
-// E2E 跑在 SSG build 後的 static output 上 (npx serve .output/public)
+// E2E 跑在 Vercel preset build 後的 static output 上 (npx serve .vercel/output/static)
 // 預期使用者先跑 `pnpm generate` 再跑 `pnpm test:e2e` (或在 CI 自動串)
+// 注意:nitro preset='vercel' 之後輸出位置從 .output/public 移到 .vercel/output/static。
+// API routes (例如 /api/discord/token) 在這個 static serve 下不可用,要打 API 的測試需
+// 用 vercel dev 或 nuxt dev。本專案 API 邏輯由 unit test (tests/unit/discordOAuth.test.ts) 覆蓋。
 const PORT = 4174;
 const BASE_URL = `http://localhost:${PORT}`;
 
@@ -30,7 +33,7 @@ export default defineConfig({
 
   // 自動 spin up serve (預期 .output/public 已 build 好)
   webServer: {
-    command: `npx serve .output/public -l ${PORT}`,
+    command: `npx serve .vercel/output/static -l ${PORT}`,
     url: BASE_URL,
     reuseExistingServer: !process.env.CI,
     timeout: 60000

--- a/server/api/discord/refresh.post.ts
+++ b/server/api/discord/refresh.post.ts
@@ -1,0 +1,26 @@
+// POST /api/discord/refresh
+// Body: { refresh_token: string }
+// Response: { access_token, refresh_token, expires_in, expires_at, token_type, scope }
+//
+// Access token 過期 (或快過期) 時 client POST refresh_token 過來,
+// server 用 client_secret 跟 Discord 換新的 access + (新的) refresh token。
+// Discord 每次 refresh 也會給新的 refresh_token,client 要覆蓋舊的儲存。
+
+import { refreshAccessToken, getOAuthConfig } from '../../utils/discord';
+
+export default defineEventHandler(async event => {
+  const body = await readBody<{ refresh_token?: string }>(event);
+  const refreshToken = body?.refresh_token;
+  if (!refreshToken || typeof refreshToken !== 'string') {
+    throw createError({ statusCode: 400, statusMessage: 'missing or invalid refresh_token' });
+  }
+
+  const cfg = getOAuthConfig();
+  try {
+    return await refreshAccessToken(cfg, refreshToken);
+  } catch (err) {
+    // refresh_token 可能也已被 revoke,這時要讓 client 知道需要重新授權
+    console.error('[discord/refresh]', err);
+    throw createError({ statusCode: 401, statusMessage: 'refresh failed, please re-authorize' });
+  }
+});

--- a/server/api/discord/revoke.post.ts
+++ b/server/api/discord/revoke.post.ts
@@ -1,0 +1,27 @@
+// POST /api/discord/revoke
+// Body: { token: string, token_type_hint?: 'access_token' | 'refresh_token' }
+// Response: 204 No Content (即使 revoke 失敗也回 204,不擋 client logout 流程)
+//
+// Logout 時 client 順便通知 Discord 把 token 作廢,避免遺留 token 被誤用。
+// 失敗不該影響 client UX (cookie 反正會被清掉),所以即使 Discord 回 error 也吞掉。
+
+import { revokeToken, getOAuthConfig } from '../../utils/discord';
+
+export default defineEventHandler(async event => {
+  const body = await readBody<{ token?: string; token_type_hint?: 'access_token' | 'refresh_token' }>(event);
+  const token = body?.token;
+  const hint = body?.token_type_hint === 'refresh_token' ? 'refresh_token' : 'access_token';
+  if (!token || typeof token !== 'string') {
+    throw createError({ statusCode: 400, statusMessage: 'missing or invalid token' });
+  }
+
+  try {
+    const cfg = getOAuthConfig();
+    await revokeToken(cfg, token, hint);
+  } catch (err) {
+    // 寫 log 但不 throw,client logout 不該被擋
+    console.error('[discord/revoke]', err);
+  }
+  setResponseStatus(event, 204);
+  return null;
+});

--- a/server/api/discord/token.post.ts
+++ b/server/api/discord/token.post.ts
@@ -1,0 +1,25 @@
+// POST /api/discord/token
+// Body: { code: string }
+// Response: { access_token, refresh_token, expires_in, expires_at, token_type, scope }
+//
+// 初次授權後 client redirect 回來帶 ?code=...,client POST 過來 server 用 client_secret
+// 跟 Discord 換 access + refresh token,然後回傳給 client 存 cookie。
+
+import { exchangeCodeForTokens, getOAuthConfig } from '../../utils/discord';
+
+export default defineEventHandler(async event => {
+  const body = await readBody<{ code?: string }>(event);
+  const code = body?.code;
+  if (!code || typeof code !== 'string') {
+    throw createError({ statusCode: 400, statusMessage: 'missing or invalid code' });
+  }
+
+  const cfg = getOAuthConfig();
+  try {
+    return await exchangeCodeForTokens(cfg, code);
+  } catch (err) {
+    // Discord 的錯誤訊息可能含敏感資訊,不直接回給 client,但 log 出來方便 debug
+    console.error('[discord/token]', err);
+    throw createError({ statusCode: 502, statusMessage: 'discord token exchange failed' });
+  }
+});

--- a/server/utils/discord.ts
+++ b/server/utils/discord.ts
@@ -1,0 +1,125 @@
+// Discord OAuth2 token exchange / refresh / revoke helpers.
+//
+// 抽到 server/utils 是為了:
+// 1. 共用邏輯不重複 (token / refresh 都用 application/x-www-form-urlencoded + Basic auth)
+// 2. 可注入 fetcher 做 unit test (避免真的打 Discord API)
+//
+// Discord 文件: https://docs.discord.com/developers/topics/oauth2
+
+export interface DiscordTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number; // 秒,Discord 預設 604800 (7 天)
+  token_type: string; // "Bearer"
+  scope: string;
+}
+
+export interface DiscordOAuthConfig {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  apiBase: string; // e.g. "https://discord.com/api"
+}
+
+// 我們回給 client 的格式 — 多加 expires_at 方便 client 算 expiry,不用各自重算
+export interface NormalizedTokenResponse extends DiscordTokenResponse {
+  expires_at: number; // ms unix timestamp,計算過後給 client 直接用
+}
+
+type Fetcher = typeof globalThis.fetch;
+
+function basicAuthHeader(id: string, secret: string): string {
+  // Buffer 在 Node、btoa 在 browser/edge runtime,server-side 用 Buffer
+  return 'Basic ' + Buffer.from(`${id}:${secret}`).toString('base64');
+}
+
+async function postTokenEndpoint(
+  cfg: DiscordOAuthConfig,
+  params: URLSearchParams,
+  fetcher: Fetcher = fetch
+): Promise<DiscordTokenResponse> {
+  const res = await fetcher(`${cfg.apiBase}/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: basicAuthHeader(cfg.clientId, cfg.clientSecret)
+    },
+    body: params.toString()
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`discord oauth error ${res.status}: ${text.slice(0, 200)}`);
+  }
+  return (await res.json()) as DiscordTokenResponse;
+}
+
+// 用 authorization code 換取 access + refresh token (initial 授權之後呼叫)
+export async function exchangeCodeForTokens(
+  cfg: DiscordOAuthConfig,
+  code: string,
+  fetcher: Fetcher = fetch
+): Promise<NormalizedTokenResponse> {
+  const params = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: cfg.redirectUri
+  });
+  const data = await postTokenEndpoint(cfg, params, fetcher);
+  return { ...data, expires_at: Date.now() + data.expires_in * 1000 };
+}
+
+// 用 refresh token 換新的 access token (access 過期時呼叫)
+// Discord 每次 refresh 也會回傳新的 refresh_token,client 應該覆蓋舊的
+export async function refreshAccessToken(
+  cfg: DiscordOAuthConfig,
+  refreshToken: string,
+  fetcher: Fetcher = fetch
+): Promise<NormalizedTokenResponse> {
+  const params = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken
+  });
+  const data = await postTokenEndpoint(cfg, params, fetcher);
+  return { ...data, expires_at: Date.now() + data.expires_in * 1000 };
+}
+
+// 取消授權 token (logout 時呼叫,讓 Discord 端也失效)
+// 注意:revoke 不返回有用資訊,失敗也不該擋 client logout
+export async function revokeToken(
+  cfg: DiscordOAuthConfig,
+  token: string,
+  tokenTypeHint: 'access_token' | 'refresh_token' = 'access_token',
+  fetcher: Fetcher = fetch
+): Promise<void> {
+  const params = new URLSearchParams({
+    token,
+    token_type_hint: tokenTypeHint
+  });
+  await fetcher(`${cfg.apiBase}/oauth2/token/revoke`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: basicAuthHeader(cfg.clientId, cfg.clientSecret)
+    },
+    body: params.toString()
+  });
+  // 不檢查 res.ok — revoke 失敗 (例如 token 已過期) 不該 throw
+}
+
+// 從 nuxt runtimeConfig 拿 OAuth 設定,集中檢查必要欄位
+export function getOAuthConfig(): DiscordOAuthConfig {
+  const config = useRuntimeConfig();
+  const clientId = (config.public.DISCORD_CLIENT_ID as string) || '';
+  const clientSecret = (config.DISCORD_CLIENT_SECRET as string) || '';
+  const redirectUri = (config.public.DISCORD_REDIRECT_URI as string) || '';
+  const apiBase = (config.public.DISCORD_API_BASE as string) || 'https://discord.com/api';
+
+  if (!clientId || !clientSecret || !redirectUri) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'discord oauth env not configured (need CLIENT_ID, CLIENT_SECRET, REDIRECT_URI)'
+    });
+  }
+  return { clientId, clientSecret, redirectUri, apiBase };
+}

--- a/tests/unit/discordOAuth.test.ts
+++ b/tests/unit/discordOAuth.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { exchangeCodeForTokens, refreshAccessToken, revokeToken } from '../../server/utils/discord';
+
+const cfg = {
+  clientId: 'test-client-id',
+  clientSecret: 'test-client-secret',
+  redirectUri: 'https://example.com/member',
+  apiBase: 'https://discord.com/api'
+};
+
+// 假裝是 fetch 的 mock,看每次 call 帶的 url + headers + body
+function mockFetch(responseBody: any, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => responseBody,
+    text: async () => JSON.stringify(responseBody)
+  } as any);
+}
+
+describe('discord oauth helpers', () => {
+  describe('exchangeCodeForTokens', () => {
+    it('POSTs to token endpoint with grant_type=authorization_code + code + redirect_uri', async () => {
+      const fakeFetch = mockFetch({
+        access_token: 'A',
+        refresh_token: 'R',
+        expires_in: 604800,
+        token_type: 'Bearer',
+        scope: 'identify'
+      });
+
+      const result = await exchangeCodeForTokens(cfg, 'the-code', fakeFetch as any);
+
+      expect(fakeFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = fakeFetch.mock.calls[0];
+      expect(url).toBe('https://discord.com/api/oauth2/token');
+      expect(init.method).toBe('POST');
+      expect(init.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+      // Basic auth header: base64("client_id:client_secret")
+      expect(init.headers.Authorization).toMatch(/^Basic /);
+      const decoded = Buffer.from(init.headers.Authorization.replace('Basic ', ''), 'base64').toString();
+      expect(decoded).toBe('test-client-id:test-client-secret');
+      // body 必須是 form-encoded 含這些欄位
+      expect(init.body).toContain('grant_type=authorization_code');
+      expect(init.body).toContain('code=the-code');
+      expect(init.body).toContain('redirect_uri=https%3A%2F%2Fexample.com%2Fmember');
+
+      expect(result.access_token).toBe('A');
+      expect(result.refresh_token).toBe('R');
+      expect(result.expires_in).toBe(604800);
+      expect(result.expires_at).toBeGreaterThan(Date.now());
+      // expires_at 應該約等於 now + 604800*1000 (誤差 < 1 秒)
+      expect(Math.abs(result.expires_at - (Date.now() + 604800 * 1000))).toBeLessThan(1000);
+    });
+
+    it('throws on non-2xx Discord response', async () => {
+      const fakeFetch = mockFetch({ error: 'invalid_grant' }, 400);
+      await expect(exchangeCodeForTokens(cfg, 'bad-code', fakeFetch as any)).rejects.toThrow(/discord oauth error 400/);
+    });
+  });
+
+  describe('refreshAccessToken', () => {
+    it('POSTs with grant_type=refresh_token + refresh_token', async () => {
+      const fakeFetch = mockFetch({
+        access_token: 'NEW_A',
+        refresh_token: 'NEW_R',
+        expires_in: 604800,
+        token_type: 'Bearer',
+        scope: 'identify'
+      });
+
+      const result = await refreshAccessToken(cfg, 'old-refresh-token', fakeFetch as any);
+
+      expect(fakeFetch).toHaveBeenCalledTimes(1);
+      const init = fakeFetch.mock.calls[0][1];
+      expect(init.body).toContain('grant_type=refresh_token');
+      expect(init.body).toContain('refresh_token=old-refresh-token');
+
+      // refresh 應該回傳新的 access + refresh (Discord 每次 refresh 都會 rotate refresh_token)
+      expect(result.access_token).toBe('NEW_A');
+      expect(result.refresh_token).toBe('NEW_R');
+      expect(result.expires_at).toBeGreaterThan(Date.now());
+    });
+
+    it('throws on non-2xx (refresh_token revoked / expired)', async () => {
+      const fakeFetch = mockFetch({ error: 'invalid_grant' }, 401);
+      await expect(refreshAccessToken(cfg, 'revoked', fakeFetch as any)).rejects.toThrow(/discord oauth error 401/);
+    });
+  });
+
+  describe('revokeToken', () => {
+    it('POSTs to revoke endpoint with token + token_type_hint', async () => {
+      const fakeFetch = mockFetch({});
+      await revokeToken(cfg, 'some-token', 'access_token', fakeFetch as any);
+
+      expect(fakeFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = fakeFetch.mock.calls[0];
+      expect(url).toBe('https://discord.com/api/oauth2/token/revoke');
+      expect(init.body).toContain('token=some-token');
+      expect(init.body).toContain('token_type_hint=access_token');
+    });
+
+    it('does NOT throw when Discord returns error (revoke failures are expected and benign)', async () => {
+      const fakeFetch = mockFetch({ error: 'invalid_token' }, 400);
+      // 即使 Discord 回 400,revoke 也不該 throw — logout 流程不該被擋
+      await expect(revokeToken(cfg, 'bad', 'access_token', fakeFetch as any)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "pnpm generate",
+  "buildCommand": "pnpm build",
   "routes": [
     {
       "src": "/voices/(.*)",


### PR DESCRIPTION
把會員專區的 Discord 認證從 **Implicit Grant** 換成 **Authorization Code Grant**,加入 refresh token 機制。Access token 7 天過期時自動用 refresh token 換新的,使用者不會被踢出登入狀態。

## 為什麼要動到後端?

Discord OAuth2 規範限制:
| 流程 | Refresh token | 需要 client_secret |
|---|---|---|
| Implicit Grant (本來用的) | ❌ 沒有 | ❌ 不需要 |
| Authorization Code Grant (本 PR) | ✅ 有 | ✅ **必須** |
| PKCE | — | Discord 不支援 |

\`client_secret\` 絕對不能放 client JS bundle (放了就公開) → 必須有 server endpoint。

## ⚠️ 部署前必做

1. **Vercel 設 \`DISCORD_CLIENT_SECRET\` env var** (server-only)
   - 從 Discord Developer Portal → App → OAuth2 → \"Reset Secret\" 拿
   - 在 Vercel project → Settings → Environment Variables 加上去 (Production / Preview / Dev 都加)
2. \`DISCORD_REDIRECT_URI\` 維持原 URL,Discord Developer Portal 不用動

如果忘記設,只有 /member 嘗試 OAuth 會 500,其他頁面照常。

## 架構改動

\`nitro.preset\`: \`static\` → \`vercel\`
- 預渲染頁面**還是**靜態 CDN
- 只有 \`/api/*\` 變 serverless functions
- vercel.json \`buildCommand\`: \`pnpm generate\` → \`pnpm build\`
- playwright e2e: \`.output/public\` → \`.vercel/output/static\`

## 新檔案

\`server/utils/discord.ts\` — shared helper, 注入式 fetcher 方便 unit test:
- \`exchangeCodeForTokens\` / \`refreshAccessToken\` / \`revokeToken\`
- \`getOAuthConfig\` 集中檢查 env 必要欄位

\`server/api/discord/*.post.ts\` (3 個 endpoint):
- \`POST /api/discord/token\`   (body: \`{ code }\`)           — initial exchange
- \`POST /api/discord/refresh\` (body: \`{ refresh_token }\`)  — refresh
- \`POST /api/discord/revoke\`  (body: \`{ token, hint }\`)    — logout

## member.vue 改動

- \`response_type\`: \`'token'\` (implicit) → \`'code'\` (auth code)
- 加 **CSRF state** 參數 (random UUID,存 sessionStorage,callback 時驗證)
- Cookies 從單一 \`discord_token\` 拆三個:
  - \`discord_access_token\` / \`discord_refresh_token\` / \`discord_token_expires_at\`
- 取得 access token 策略雙保險:
  - **Proactive**: 每次 Discord API 前檢查 \`expires_at < now+60s\` → 先 refresh
  - **Reactive**: \`callDiscord\` 收到 401 → 試 refresh 一次後 retry
- 移除 \`prompt=none\` (initial auth 不能用,refresh token 本身就解決免互動 renew)
- Logout 順便 revoke + clear 三個 cookies

## i18n
新增 \`member.error_state_mismatch\` (zh/ja/en) — CSRF state 不一致時提示

## Tests
- **Unit** (\`tests/unit/discordOAuth.test.ts\`, 6 tests):
  - exchange POST 正確 endpoint + Basic auth + form-encoded body + \`expires_at\` 計算
  - refresh POST 正確 \`grant_type=refresh_token\`
  - revoke POST 正確 endpoint + \`token_type_hint\`;Discord 回錯也不 throw (logout 不擋)
- **E2E**: 既有 63 個 tests 都還過 (member 流程不能在 e2e 真的跑 OAuth,改用 unit 覆蓋)

## 驗證
- [x] Unit: 62/62 (56 既有 + 6 新)
- [x] E2E: 63/63
- [x] Lint clean
- [x] \`pnpm build\` (vercel preset) — functions 都產出
- [x] \`pnpm generate\` (本地) — static 還是出得來

## 之後若想再優化 (留 follow-up)
- 把 token cookies 改成 HttpOnly 由 server 端 \`Set-Cookie\` 設,避免 XSS 偷 token (現在跟 PR 前一樣 client-stored,沒退步,但有改善空間)

🤖 Generated with [Claude Code](https://claude.com/claude-code)