### PR TITLE
fix(member): PR19 - voice list missing after auth (direct import dc_voices.json)

### DIFF
--- a/app/pages/member.vue
+++ b/app/pages/member.vue
@@ -80,6 +80,7 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { mdiLink } from '@mdi/js';
+import dcVoices from '~~/public/dc_voices.json';
 import { useAudioStore } from '~/stores/audio';
 import { useSnackbar } from '~/composables/useSnackbar';
 
@@ -88,10 +89,17 @@ definePageMeta({
   ssr: false
 });
 
-// dc_voices.json 走 public/ 靜態檔 (PR17 修)
-const { data: voice_lists } = await useAsyncData('dc_voices', () => $fetch('/dc_voices.json'), {
-  default: () => ({ groups: [] })
-});
+// dc_voices.json (~400KB) 直接 import,讓 Vite 內聯進 member 頁的 chunk。
+//
+// 歷史:
+//   PR8 改成 $fetch('/api/dc_voices') server route (不出貨進 client bundle)
+//   PR17 因為 SSG 靜態 hosting 沒 runtime api,改成 $fetch('/dc_voices.json')
+//   PR19 (本次) 因 useAsyncData('dc_voices', $fetch('/dc_voices.json')) 在
+//        ssr:false + Vercel preset + SPA navigation 路徑下 voice_lists.value
+//        會變空 object {} (花了一小時 debug 找不到原因),直接 import 最可靠。
+//
+// 代價:member 頁的 chunk 多 ~400KB,但 member 是低流量頁 (有 Discord 才看),
+//      初次載入慢一點 OK。
 
 const { t, locale } = useI18n();
 const settings = useSettingsStore();
@@ -112,8 +120,8 @@ const accessTokenCookie = useCookie('discord_access_token', COOKIE_OPTS);
 const refreshTokenCookie = useCookie('discord_refresh_token', COOKIE_OPTS);
 const expiresAtCookie = useCookie('discord_token_expires_at', COOKIE_OPTS);
 
-// 狀態變數
-const groups = computed(() => voice_lists.value.groups);
+// 狀態變數 — groups 直接從 import 來,不需 reactive
+const groups = dcVoices.groups;
 const loading = ref(true);
 const error = ref(null);
 const account = ref(null);


### PR DESCRIPTION
## Bug
使用者報告 OAuth 認證完成後 (看到「您已獲准查看此頁面」alert) 但 **dc 語音列表沒有跟著顯示**。

## Root cause
PR17 / PR18 用 \`useAsyncData('dc_voices', () => \$fetch('/dc_voices.json'))\`。在以下情境會壞:
- \`definePageMeta({ ssr: false })\`
- Nitro preset \`vercel\`
- SPA navigation (從首頁 drawer 點進 /member,非直接 URL 訪問)

\`voice_lists.value\` 拿到的不是預設值 \`{ groups: [] }\`,也不是真的 JSON 內容,而是**空 object \`{}\`**。Debug 過程:
- 直接 curl/瀏覽器 fetch \`/dc_voices.json\` → 200 + 327KB 正常
- 但 useAsyncData 拿到的就是空 object
- 嘗試換 \`$fetch\` → 仍然空
- 換 native fetch + .json() → 仍然空
- 完全清掉 build cache + 重 build 後,member 的 chunk 載入正常,但本質的 useAsyncData 在這個組合下還是有問題
- 花了一小時 debug 找不到具體 root cause (可能是 Nuxt + Vercel preset + SPA chunk loading 的 race condition)

決定不再 fetch,改最可靠的方式。

## Fix
\`member.vue\` 直接 \`import dcVoices from '~~/public/dc_voices.json'\`。Vite 在 build time 把 JSON 內聯進 member 頁的 chunk。\`groups\` 直接從 import 拿,不用 reactive ref。

\`\`\`diff
- const { data: voice_lists } = await useAsyncData('dc_voices', () => \$fetch('/dc_voices.json'), ...);
- const groups = computed(() => voice_lists.value.groups);
+ import dcVoices from '~~/public/dc_voices.json';
+ const groups = dcVoices.groups;
\`\`\`

## Trade-off
PR8 當時把 dc_voices.json 拆出 client bundle 是為了砍 JS 大小。Member 頁的 chunk 會多 ~400KB,但:
- Member 是低流量頁 (需 Discord 才能看)
- Chunk 是 lazy load 只在 user 點進去時才下載
- 「會員區渲染慢一點」OK

對其他頁面零影響。

## 驗證
- [x] 63/63 e2e 全綠 (含 member.spec.ts 的 drawer → /member → dc_voices 載入無 404)
- [x] 62/62 unit
- [x] Lint clean
- [x] 從本機 build + serve 模擬 SPA 導航,member 頁能正常 render

🤖 Generated with [Claude Code](https://claude.com/claude-code)