### PR TITLE
fix(compose): PR20 - light mode item colors theme-aware

### DIFF
--- a/app/pages/compose.vue
+++ b/app/pages/compose.vue
@@ -261,7 +261,6 @@ import draggable from 'vuedraggable';
 import {
   mdiPlayCircleOutline,
   mdiStopCircleOutline,
-  mdiRepeat,
   mdiTrashCanOutline,
   mdiDragVertical,
   mdiPlayOutline,
@@ -389,10 +388,11 @@ useSeoMeta({
 </script>
 
 <style scoped>
-/* ===== 編輯區卡片:用中性 bg 取代 elevation overlay 帶來的紅色 tint ===== */
+/* ===== 編輯區卡片:用 on-surface 的低 alpha tint,light/dark 自動反向 ===== */
 .composer-card {
-  background-color: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  /* on-surface = 文字色,在 dark 是白、light 是黑,做 0.04 alpha overlay 都能微微「升一階」 */
+  background-color: rgba(var(--v-theme-on-surface), 0.04);
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.08);
 }
 .composer-toolbar {
   background-color: transparent !important;
@@ -401,28 +401,35 @@ useSeoMeta({
   background-color: transparent;
 }
 
-/* ===== 編輯區 item:中性灰底 + 細邊框,hover 才微亮 ===== */
+/* ===== 編輯區 item:用 Vuetify surface 變數 (opaque + theme-aware) ===== */
 .composer-list {
   list-style: none;
 }
 .composer-item {
-  /* 不透明背景,比 card 底 (#43404b + 微亮 overlay) 暗一些,呈現「卡片內的次層級 item」感 */
-  background-color: #2a2730;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  /* 不透明背景。Dark: surface=#212121 (比 card 暗,呈下凹);
+     Light: surface=#ffffff (比 page bg #a29db3 亮,呈卡片浮起)。兩 mode 都自然分層 */
+  background-color: rgb(var(--v-theme-surface));
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.08);
   transition:
     background-color 0.18s,
     border-color 0.18s;
   min-height: 56px;
 }
 .composer-item:hover {
-  background-color: #353140;
+  background-color: rgb(var(--v-theme-surface-light));
 }
 
-/* 播放中的當前條:不透明 primary tinted bg + 左邊框條 */
+/* 播放中當前條:primary tinted bg + 左邊框條。
+   用 theme-specific 蓋掉,保持不透明 (使用者要求 opaque) */
 .composer-item-playing {
-  background-color: #4a1f2e !important; /* opaque primary-tinted dark */
   border-color: rgb(var(--v-theme-primary)) !important;
   border-left-width: 4px !important;
+}
+.v-theme--dark .composer-item-playing {
+  background-color: #4a1f2e !important; /* 暗紅色,跟 dark surface 對比夠 */
+}
+.v-theme--light .composer-item-playing {
+  background-color: #fde7ec !important; /* 淺粉色,跟 light surface (白) 對比夠 */
 }
 
 /* 「播放中」icon 的脈動動畫 — 多一層 a11y 視覺指示 */
@@ -441,7 +448,7 @@ useSeoMeta({
   }
 }
 
-/* 編號小圓 badge */
+/* 編號小圓 badge (註:目前 template 沒在用,留著當參考) */
 .composer-item-index {
   display: inline-flex;
   align-items: center;
@@ -449,10 +456,10 @@ useSeoMeta({
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background-color: rgba(255, 255, 255, 0.08);
+  background-color: rgba(var(--v-theme-on-surface), 0.08);
   font-size: 0.75rem;
   font-weight: 700;
-  color: rgba(255, 255, 255, 0.75);
+  color: rgba(var(--v-theme-on-surface), 0.75);
   flex-grow: 0;
   flex-shrink: 0;
 }

--- a/tests/e2e/compose.spec.ts
+++ b/tests/e2e/compose.spec.ts
@@ -168,15 +168,17 @@ test.describe('Voice Compose page', () => {
     await expect(addBtn).toBeEnabled();
   });
 
-  test('loop toggle changes button label', async ({ page, context }) => {
+  test('loop switch toggles state', async ({ page, context }) => {
     await context.clearCookies();
     await page.goto('/compose');
     await page.waitForLoadState('networkidle');
 
-    const loopBtn = page.getByRole('button', { name: /^循環$/ });
-    await expect(loopBtn).toBeVisible();
-    await loopBtn.click();
-    await expect(page.getByRole('button', { name: /^循環中$/ })).toBeVisible();
+    // 循環現在是 v-switch (Vuetify 渲染成 input[type=checkbox])
+    const loopSwitch = page.getByRole('checkbox', { name: /循環/ });
+    await expect(loopSwitch).toBeVisible();
+    await expect(loopSwitch).not.toBeChecked();
+    await loopSwitch.click();
+    await expect(loopSwitch).toBeChecked();
   });
 });
 


### PR DESCRIPTION
## Bug
編輯區 \`.composer-item\` / \`.composer-card\` / \`.composer-item-playing\` 用寫死的深色 (\`#2a2730\` / \`#353140\` / \`#4a1f2e\`),只在 dark mode 看起來對。Light mode 時 item 還是顯示深紫灰底,跟 light theme 整體不搭。

## Fix
全部換成 Vuetify theme-aware:

\`\`\`diff
.composer-card {
-  background-color: rgba(255, 255, 255, 0.04);
+  background-color: rgba(var(--v-theme-on-surface), 0.04);
}
.composer-item {
-  background-color: #2a2730;
+  background-color: rgb(var(--v-theme-surface));
}
.composer-item:hover {
-  background-color: #353140;
+  background-color: rgb(var(--v-theme-surface-light));
}
.composer-item-playing {
-  background-color: #4a1f2e !important;
+}
+.v-theme--dark  .composer-item-playing { background-color: #4a1f2e !important; }
+.v-theme--light .composer-item-playing { background-color: #fde7ec !important; }
\`\`\`

**設計邏輯**:
- \`on-surface alpha overlay\`:dark 時白色 tint,light 時黑色 tint,兩個 mode 都「升一階」
- \`var(--v-theme-surface)\`:dark=#212121 (比 card 暗,下凹感) / light=#ffffff (比 page bg #a29db3 亮,卡片浮起感)
- \`composer-item-playing\` 上次使用者明確要 opaque,所以拆兩條 theme-specific:dark 用暗紅、light 用淺粉,兩種跟各自 surface 對比都夠

## Visual

**Dark mode** (原本就 OK):
- 編輯區卡片暗灰、item 更暗、播放條暗紅

**Light mode** (本 PR 修):
- 編輯區卡片淺色 overlay、item 白色 raised、播放條淺粉
- 跟 light theme 的 \`#a29db3\` page bg 自然分層

**Playing state (light)**: 淺粉底 + 紅左邊框 + 「播放中」紅字 ✓

## 附帶清理
- 移掉 \`mdiRepeat\` import (loop button 之前已改用 \`v-switch\` 後沒在用)
- 更新 e2e \`compose.spec.ts\`:\`loop toggle\` test 改用 \`getByRole('checkbox', { name: /循環/ })\` + \`toBeChecked\` (v-switch 渲染成 input[type=checkbox])

## 驗證
- [x] 63/63 e2e
- [x] 62/62 unit
- [x] Lint clean
- [x] 截圖驗 dark / light / light playing 三狀態都正確

🤖 Generated with [Claude Code](https://claude.com/claude-code)