### PR TITLE
fix(compose): only auto-scroll to playing item when offscreen

### DIFF
--- a/app/pages/compose.vue
+++ b/app/pages/compose.vue
@@ -135,11 +135,6 @@
                     :disabled="composer.isPlaying"
                   ></v-btn>
 
-                  <!-- 編號 (圓形 badge 風格) -->
-                  <!-- <span class="composer-item-index" :aria-label="$t('compose.item_position', { pos: index + 1 })">
-                    {{ index + 1 }}
-                  </span> -->
-
                   <!-- 名稱 + 群組標 -->
                   <div class="flex-grow-1 d-flex flex-column" style="min-width: 0">
                     <span class="text-caption text-medium-emphasis composer-item-group">
@@ -367,7 +362,8 @@ const onResetConfirm = () => {
   showResetConfirm.value = false;
 };
 
-// 播放中 currentIndex 變動時自動 scroll 到當前條 (讓使用者跟得上)
+// 播放中 currentIndex 變動時,如果當前條不在 viewport 才 scroll (避免在使用者已能看到的
+// 情況下還強制 scroll,反而干擾)
 watch(
   () => composer.currentIndex,
   idx => {
@@ -375,7 +371,14 @@ watch(
     nextTick(() => {
       const items = document.querySelectorAll('.composer-item');
       const target = items[idx];
-      if (target) target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      if (!target) return;
+      const rect = target.getBoundingClientRect();
+      const viewportH = window.innerHeight || document.documentElement.clientHeight;
+      // 完全在 viewport 內 = 上下邊都在範圍內就不 scroll
+      const isFullyInView = rect.top >= 0 && rect.bottom <= viewportH;
+      if (!isFullyInView) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
     });
   }
 );
@@ -446,26 +449,6 @@ useSeoMeta({
     opacity: 0.55;
     transform: scale(0.92);
   }
-}
-
-/* 編號小圓 badge (註:目前 template 沒在用,留著當參考) */
-.composer-item-index {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background-color: rgba(var(--v-theme-on-surface), 0.08);
-  font-size: 0.75rem;
-  font-weight: 700;
-  color: rgba(var(--v-theme-on-surface), 0.75);
-  flex-grow: 0;
-  flex-shrink: 0;
-}
-.composer-item-playing .composer-item-index {
-  background-color: rgb(var(--v-theme-primary));
-  color: white;
 }
 
 .composer-item-group {


### PR DESCRIPTION
## Summary
- 一鍵播放時,若下一條語音已經在視窗內可見就不要強制 scroll,避免干擾使用者
- 用 `getBoundingClientRect()` 比對 `window.innerHeight` 判斷是否完整在 viewport (top >= 0 且 bottom <= viewportH),不在才呼叫 `scrollIntoView`
- 順手清掉一段 commented-out 的 `composer-item-index` template + 對應 CSS (早期實驗的死碼)

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test:unit` (62 passed)
- [x] `pnpm generate`
- [x] `pnpm test:e2e` (63 passed)
- [ ] 手動: 在 /compose 加一條 voice (頂端可見) → 一鍵播放 → 不應 scroll
- [ ] 手動: 加 30 條 voice → 一鍵播放 → 切換到不可見的下一條時應 smooth scroll 到中間

🤖 Generated with [Claude Code](https://claude.com/claude-code)