### PR TITLE
fix: vercel analytics + member voice button text overflow

### DIFF
--- a/app/components/VoiceBtn.vue
+++ b/app/components/VoiceBtn.vue
@@ -249,7 +249,10 @@ $nonlinear-transition: cubic-bezier(0.25, 0.8, 0.5, 1);
   border-color: rgba(255, 255, 255, 0.12) !important;
 }
 
-:deep(.vo-btn) {
+// 不用 :deep() — :deep(.vo-btn) 會編譯成 `[data-v-x] .vo-btn`,在 v-else 的 standalone
+// branch 沒有帶 data-v 的祖先 (v-hover 不 render 根),這些規則就吃不到,長文字會被
+// Vuetify 預設 height:36px / inline-grid 卡住而溢出。.vo-btn 自己有 scope,直接寫即可。
+.vo-btn {
   display: inline-block;
   height: max-content !important;
   min-height: 36px;
@@ -257,17 +260,18 @@ $nonlinear-transition: cubic-bezier(0.25, 0.8, 0.5, 1);
   z-index: 2;
 }
 
-:deep(.vo-btn .v-btn__content) {
+.vo-btn.full-width {
+  max-width: 100%;
+}
+
+// .v-btn__content 是 Vuetify 內部 render,沒有我們的 scope,需要 :deep。
+.vo-btn :deep(.v-btn__content) {
   word-wrap: break-word !important;
   word-break: break-all !important;
   white-space: normal !important;
   text-transform: none !important;
   font-weight: 400;
   text-align: center;
-}
-
-.vo-btn.full-width {
-  max-width: 100%;
 }
 
 .vo-btn-bg-light {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -60,7 +60,9 @@ export default defineNuxtConfig({
     // SEO 主套件:整合 sitemap / robots / schema-org / og-image / link-checker
     '@nuxtjs/seo',
     // 圖片優化:自動 WebP/AVIF、lazy、srcset
-    '@nuxt/image'
+    '@nuxt/image',
+    // Vercel Web Analytics — 自動 inject `_vercel/insights/script.js` 並追蹤 pageview/route
+    '@vercel/analytics/nuxt'
   ],
 
   // @nuxt/image 設定

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
+    "@vercel/analytics": "^2.0.1",
     "markdown-it": "^14.1.1",
     "nuxt": "^4.3.1",
     "twemoji": "^14.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@mdi/js':
         specifier: ^7.4.47
         version: 7.4.47
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(nuxt@4.3.1(@parcel/watcher@2.5.6)(@types/node@25.3.3)(@vue/compiler-sfc@3.5.29)(cac@7.0.0)(commander@11.1.0)(db0@0.3.4)(eslint@10.0.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(vue-router@4.6.4(vue@3.5.29(typescript@5.9.3)))(vue@3.5.29(typescript@5.9.3))
       markdown-it:
         specifier: ^14.1.1
         version: 14.1.1
@@ -3078,6 +3081,35 @@ packages:
     resolution: {integrity: sha512-Y3pPVibbIOHzohrlxSINvO7w/bvXkoYS3BQHoImV9ynE+bXKf171bdMucPurV2zp7gdmt0L1HCcNAsbo7cFRQw==}
     peerDependencies:
       valibot: ^1.4.0
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/nft@1.3.2':
     resolution: {integrity: sha512-HC8venRc4Ya7vNeBsJneKHHMDDWpQie7VaKhAIOst3MKO+DES+Y/SbzSp8mFkD7OzwAE2HhHkeSuSmwS20mz3A==}
@@ -10922,6 +10954,12 @@ snapshots:
   '@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@5.9.3))':
     dependencies:
       valibot: 1.4.0(typescript@5.9.3)
+
+  '@vercel/analytics@2.0.1(nuxt@4.3.1(@parcel/watcher@2.5.6)(@types/node@25.3.3)(@vue/compiler-sfc@3.5.29)(cac@7.0.0)(commander@11.1.0)(db0@0.3.4)(eslint@10.0.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(vue-router@4.6.4(vue@3.5.29(typescript@5.9.3)))(vue@3.5.29(typescript@5.9.3))':
+    optionalDependencies:
+      nuxt: 4.3.1(@parcel/watcher@2.5.6)(@types/node@25.3.3)(@vue/compiler-sfc@3.5.29)(cac@7.0.0)(commander@11.1.0)(db0@0.3.4)(eslint@10.0.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+      vue: 3.5.29(typescript@5.9.3)
+      vue-router: 4.6.4(vue@3.5.29(typescript@5.9.3))
 
   '@vercel/nft@1.3.2(rollup@4.59.0)':
     dependencies:


### PR DESCRIPTION
兩個獨立小 fix 一起進來:

1. 接 Vercel Web Analytics
   - 加 @vercel/analytics + 把 @vercel/analytics/nuxt 加進 modules
   - 之前只有 nuxt-gtag (GA),Vercel dashboard 看不到任何 data;module 會自動在 client 端 inject va.vercel-scripts.com 的 script 並追蹤 SPA route 變動。

2. /member 語音按鈕長文字破版 Root cause: VoiceBtn 的 v-else (standalone full-width) branch — 只有 /member 會走這條 (其他頁的 voices 都有 url → from-youtube=true → group variant)。
   - 原 CSS 用 `:deep(.vo-btn) { height: max-content; display: inline-block; ... }`
   - Vue scoped CSS 把 `:deep(.vo-btn)` 編成 `[data-v-x] .vo-btn`,需要帶 scope 的祖先元素。group variant 有 `<v-btn-group>` 當祖先 (data-v 存在),所以吃得到。
   - standalone branch 的 v-btn 是 v-hover slot 的直接子節點,v-hover 不 render 根 → 沒有任何祖先帶 VoiceBtn 的 data-v → :deep 規則完全失效 → Vuetify 預設 `height: 36px; display: inline-grid; .v-btn__content { white-space: nowrap }` 接管,長文字被卡在 36px 高的按鈕內溢出。
   - Fix: `.vo-btn` 自己就在 template 裡,本來就有 data-v,把外層 `:deep()` 拿掉, 兩個 variant 都吃到。`.v-btn__content` 才需要 :deep (Vuetify 內部 render)。

驗證: dev server 暫時繞過 auth 進 /member,191 字長文字按鈕的 computed style 由
`height: 36px, white-space: nowrap, display: grid` 變成 `height: 96px,
white-space: normal, word-break: break-all`,文字正常 wrap。Group variant 在
首頁照常工作 (max-width: calc(100% - 48px) 沒變)。

pnpm lint + pnpm test:unit (62 passed) 全綠。pnpm generate 本機環境有 sitemap module postinstall 衝突 (master 也是),不影響 Vercel 上 frozen-lockfile install。